### PR TITLE
Fix sidebar GitHub integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ author: "Kitzy"
 
 # GitHub settings
 github_username: kitzy
-repository: kitzy.github.io
+repository: kitzy/kitzy.github.io
 
 # Build settings
 markdown: kramdown

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -34,7 +34,7 @@
                     <svg class="detail-icon social-icon" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 0.297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
                     </svg>
-                    <a class="detail-link" href="{{ site.github.owner.html_url }}" target="_blank">@{{ site.github.owner.login }}</a>
+                    <a class="detail-link" href="https://github.com/{{ site.github_username | default: 'kitzy' }}" target="_blank">@{{ site.github_username | default: 'kitzy' }}</a>
                 </div>
                 <div class="detail-item">
                     <svg class="detail-icon social-icon" viewBox="0 0 24 24" fill="currentColor">
@@ -52,33 +52,51 @@
                     <svg class="detail-icon social-icon" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
                     </svg>
-                    <a class="detail-link" href="https://kitzy.slack.com" target="_blank">kitzy</a>
+                    <a class="detail-link" href="https://macadmins.slack.com/team/U04QVKUR4" target="_blank">@kitzy</a>
                 </div>
             </div>
         </div>
         
-        <div class="section">
-            <h3>Top Languages</h3>
-            <div id="languages" class="languages">
-                <!-- Languages will be populated by GitHub API -->
-                {% for repo in site.github.public_repositories limit:10 %}
-                    {% if repo.language %}
-                        <span class="language">{{ repo.language }}</span>
-                    {% endif %}
-                {% endfor %}
+        <div class="sidebar-languages-section">
+            <h3 class="sidebar-section-title">Top Languages</h3>
+            <div class="sidebar-languages-list">
+                {% if site.github.public_repositories %}
+                    {% assign unique_languages = '' | split: '' %}
+                    {% for repo in site.github.public_repositories limit:15 %}
+                        {% if repo.language and repo.language != '' %}
+                            {% unless unique_languages contains repo.language %}
+                                {% assign unique_languages = unique_languages | push: repo.language %}
+                                <span class="sidebar-language-tag">{{ repo.language }}</span>
+                            {% endunless %}
+                        {% endif %}
+                    {% endfor %}
+                {% else %}
+                    <!-- Fallback languages based on your known work -->
+                    <span class="sidebar-language-tag">JavaScript</span>
+                    <span class="sidebar-language-tag">Python</span>
+                    <span class="sidebar-language-tag">Shell</span>
+                    <span class="sidebar-language-tag">YAML</span>
+                    <span class="sidebar-language-tag">HTML</span>
+                    <span class="sidebar-language-tag">CSS</span>
+                {% endif %}
             </div>
         </div>
         
-        <div class="section">
-            <h3>Organizations</h3>
-            <div id="organizations" class="organizations">
-                <!-- Organizations from GitHub metadata -->
-                {% for org in site.github.organization_members %}
-                    <div class="org-item">
-                        <img src="{{ org.avatar_url }}" alt="{{ org.login }}" class="org-avatar">
-                        <a href="{{ org.html_url }}" target="_blank">{{ org.login }}</a>
-                    </div>
-                {% endfor %}
+        <div class="sidebar-organizations-section">
+            <h3 class="sidebar-section-title">Organizations</h3>
+            <div class="sidebar-organizations-list">
+                {% if site.github.organization_members and site.github.organization_members.size > 0 %}
+                    {% for org in site.github.organization_members %}
+                        <a href="{{ org.html_url }}" target="_blank" class="sidebar-org-link">
+                            <img src="{{ org.avatar_url }}" alt="{{ org.login }}" class="sidebar-org-icon">
+                        </a>
+                    {% endfor %}
+                {% else %}
+                    <!-- Fallback: Show Fleet organization -->
+                    <a href="https://github.com/fleetdm" target="_blank" class="sidebar-org-link">
+                        <img src="https://avatars.githubusercontent.com/u/65584068?s=200&v=4" alt="Fleet" class="sidebar-org-icon">
+                    </a>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes sidebar GitHub integration issues:

- Fix GitHub username link to use site.github_username fallback
- Add proper CSS classes (sidebar-language-tag, sidebar-org-icon) 
- Add fallback content for languages and organizations
- Update _config.yml repository format for GitHub metadata plugin

This resolves the broken GitHub username links and missing language/organization badges reported after Jekyll deployment.