### PR TITLE
Fix README page content display

### DIFF
--- a/_pages/readme.md
+++ b/_pages/readme.md
@@ -1,13 +1,124 @@
 ---
 layout: default
 title: README.md
-description: "Personal user manual and work philosophy"
+description: "Personal user manual and work philosophy - Because people don't come with instruction booklets"
 permalink: /readme/
 ---
 
 <div class="markdown-content">
     <h1>README.md</h1>
-    <p>This page will contain your personal user manual content. The original README.md file content will be displayed here once properly configured.</p>
     
-    <p>For now, this is a placeholder. The Jekyll conversion maintains all your original styling while enabling proper social media previews.</p>
+    <p><em>Because people don't come with instruction booklets (but wouldn't it be easier if they did?). This is mine. It's here to help you understand how I tick, how I work best, and how we can collaborate without stepping on rakes together.</em></p>
+    
+    <hr>
+    
+    <h2>Who I am</h2>
+    <p>I'm a mix of big-heartedness, curiosity, and creativity. My <a href="https://en.wikipedia.org/wiki/Enneagram_of_Personality">Enneagram</a> results put me as:</p>
+    <ul>
+        <li><strong>Type 2 (Helper):</strong> Warm, caring, people-oriented. I want to support others and make the team feel like a safe, connected place.</li>
+        <li><strong>Type 7 (Enthusiast):</strong> Energetic, curious, and idea-hungry. I thrive on variety and love chasing possibilities.</li>
+        <li><strong>Type 4 (Individualist):</strong> Authentic, creative, and reflective. I bring depth and individuality, sometimes with a flair of moodiness.</li>
+    </ul>
+    
+    <p>I'm also <strong><a href="https://embrace-autism.com/an-introduction-to-audhd/">AuDHD (autism + ADHD)</a></strong>, which colors how I think and work:</p>
+    <ul>
+        <li>I usually have about seven trains of thought running at once, sometimes in different directions, sometimes colliding in a glorious mental pile-up.</li>
+        <li>Time blindness is real. If I'm late to a meeting, I didn't forget you—I just fell down a rabbit hole. A quick ping is like tossing me a rope.</li>
+        <li>I sometimes interrupt because I think I can already see where you're going, but I'm learning to hit pause and let people land their sentences.</li>
+        <li>Also, did anyone see where I left my AirPods? No, seriously.</li>
+    </ul>
+    
+    <hr>
+    
+    <h2>My values</h2>
+    <ul>
+        <li><strong>Empathy as a baseline:</strong> I believe life is better when people look out for each other. Thoughtfulness and small acts of care go a long way with me.</li>
+        <li><strong>Curiosity first:</strong> I'd rather ask questions and explore possibilities than pretend to know everything. For me, curiosity is the gateway to clarity.</li>
+        <li><strong>Authenticity over polish:</strong> I'd rather things be real and imperfect than fake and shiny. I value honesty and transparency, even when the truth is messy.</li>
+        <li><strong>Growth and learning:</strong> Mistakes happen; what matters is taking responsibility, adapting, and improving. I'll own my work and my missteps, and I appreciate when others do too.</li>
+        <li><strong>Playfulness:</strong> Humor and lightness make hard work more sustainable. I believe we can take our work seriously without taking <em>ourselves</em> too seriously.</li>
+    </ul>
+    
+    <hr>
+    
+    <h2>How I work best</h2>
+    <ul>
+        <li>I get inspired at odd hours. If I message you at midnight, that's just the hamster in my brain choosing to sprint on the wheel. Please don't feel pressure to respond outside your normal hours.</li>
+        <li>Collaboration fuels me. I'm happiest when I can bounce ideas around like mental ping-pong.</li>
+        <li>Variety keeps me energized. Give me a buffet of tasks, and I'll happily graze.</li>
+        <li>Clear priorities help me focus. Otherwise I may try to juggle flaming torches <em>and</em> chainsaws simultaneously.</li>
+    </ul>
+    
+    <hr>
+    
+    <h2>How to communicate with me</h2>
+    <ul>
+        <li><strong>Be clear and kind.</strong> I love warmth, but I also need straightforwardness.</li>
+        <li><strong>Explicit is better than implicit.</strong> Subtle hints often sneak right past me.</li>
+        <li><strong>Quick check-ins help.</strong> A simple "just confirming you're good with this?" is magic.</li>
+        <li><strong>Ping me if I'm late.</strong> Think of it as tapping me on the shoulder in the time-fog.</li>
+    </ul>
+    
+    <hr>
+    
+    <h2>Things to know about me</h2>
+    <ul>
+        <li>I sometimes overcommit because my enthusiasm writes checks my calendar can't cash. A reminder to pace myself is always welcome.</li>
+        <li>I can get so busy helping others that I forget to drink water or breathe. Gentle nudges to take care of myself are appreciated.</li>
+        <li>My brain alternates between hyperfocus (deep in the matrix) and scatter (every shiny thing is suddenly fascinating). Both are normal settings for me.</li>
+        <li>Authenticity matters to me. If something's off, just tell me. I'll take honesty over guesswork any day.</li>
+    </ul>
+    
+    <hr>
+    
+    <h2>How to support me</h2>
+    <ul>
+        <li><strong>Watch for signals.</strong> If I get snappy, bossy, or perfectionistic, I'm probably feeling unappreciated or overloaded. A little acknowledgment helps more than you'd think.</li>
+        <li><strong>Remind me of boundaries.</strong> Sometimes I try to be everyone's emotional support human. Remind me it's okay to step back.</li>
+        <li><strong>Anchor me in priorities.</strong> When stress hits, my inner Type 7 scatters like confetti. Help me pick up the right piece first.</li>
+        <li><strong>Allow my moods.</strong> My Type 4 side sometimes goes "moody indie soundtrack." I don't need fixing—just space.</li>
+        <li><strong>Humor works.</strong> A well-timed joke resets me better than a motivational poster ever could.</li>
+    </ul>
+    
+    <hr>
+    
+    <h2>How I like to receive feedback</h2>
+    <ul>
+        <li><strong>Direct is best.</strong> I don't do well with vague hints. If something's off, say it plainly.</li>
+        <li><strong>Kindness matters.</strong> I'm open to constructive criticism, but I'll absorb it more easily if it's framed with care.</li>
+        <li><strong>Timely > perfect.</strong> Don't wait weeks to craft the perfect message, tell me soon while it's fresh and actionable.</li>
+        <li><strong>Private first, public later.</strong> Critical feedback lands best in private. Positive feedback can be anywhere (and I'll probably beam like a proud raccoon).</li>
+        <li><strong>Pair it with clarity.</strong> If you can, include specific examples or suggestions. Otherwise my brain may spiral trying to fill in the blanks.</li>
+    </ul>
+    
+    <hr>
+    
+    <h2>What I value in coworkers</h2>
+    <ul>
+        <li>Authenticity and honesty (yes, even blunt honesty).</li>
+        <li>Thoughtfulness—small kindnesses land big with me.</li>
+        <li>Curiosity and playfulness—problem-solving doesn't have to be boring.</li>
+        <li>Respect for different rhythms and quirks—neurodivergence is part of the team, not a bug.</li>
+    </ul>
+    
+    <hr>
+    
+    <h2>Quick reference</h2>
+    
+    <p><strong>Energizes me:</strong></p>
+    <ul>
+        <li>Brainstorming and bouncing ideas</li>
+        <li>Variety and new challenges</li>
+        <li>Humor and playfulness</li>
+        <li>Feeling useful and supportive</li>
+        <li>Clear goals (plus room to get creative in how to reach them)</li>
+    </ul>
+    
+    <p><strong>Drains me:</strong></p>
+    <ul>
+        <li>Ambiguity and unclear expectations (my brain fills in the blanks with chaos)</li>
+        <li>Endless repetitive tasks</li>
+        <li>Being taken for granted when I've overextended</li>
+        <li>Feeling like I have to "mask" my quirks</li>
+    </ul>
 </div>


### PR DESCRIPTION
📖 **Replace placeholder content with actual personal user manual**

## Problem:
The  page was showing placeholder text instead of the comprehensive personal user manual content from .

## Solution:
- **Added complete README content**: All sections from the original README.md now display properly
- **Proper HTML formatting**: Converted markdown to HTML with proper links and emphasis
- **Improved meta description**: Better SEO and social preview description
- **Maintained styling**: Keeps the existing CSS classes and layout structure

## Content Added:
✅ **Who I am** - Enneagram types and AuDHD context  
✅ **My values** - Core principles and beliefs  
✅ **How I work best** - Optimal working conditions  
✅ **Communication preferences** - Clear, direct feedback approach  
✅ **Things to know** - Important quirks and patterns  
✅ **Support strategies** - How to help when overwhelmed  
✅ **Feedback preferences** - Direct, kind, timely approach  
✅ **Coworker values** - What I appreciate in teammates  
✅ **Quick reference** - Energizers vs. drains summary  

This transforms the README page from a placeholder into a comprehensive personal user manual that helps colleagues understand how to work effectively with Kitzy.