### PR TITLE
Add external content integration for About page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,5 +42,6 @@
     <script src="https://cdn.jsdelivr.net/npm/marked@4.3.0/marked.min.js"></script>
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/github-integration.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/external-content.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/js/external-content.js
+++ b/assets/js/external-content.js
@@ -1,0 +1,89 @@
+/**
+ * External Repository Content Integration
+ * Fetches README content from kitzy/kitzy repository for About page
+ */
+
+async function loadExternalAboutContent() {
+    const aboutContainer = document.getElementById('external-about-content');
+    
+    if (!aboutContainer) {
+        return; // Only run on pages that have the container
+    }
+    
+    try {
+        console.log('Loading About content from kitzy/kitzy repository');
+        
+        // Fetch README.md from kitzy/kitzy repo
+        const response = await fetch('https://api.github.com/repos/kitzy/kitzy/contents/README.md');
+        
+        if (!response.ok) {
+            throw new Error(`GitHub API responded with ${response.status}`);
+        }
+        
+        const data = await response.json();
+        
+        // Decode base64 content
+        const content = atob(data.content);
+        
+        // Convert markdown to HTML using marked.js (already loaded on page)
+        const htmlContent = marked.parse(content);
+        
+        // Update the container with fetched content
+        aboutContainer.innerHTML = htmlContent;
+        
+        // Fix any relative links to point to the source repo
+        const links = aboutContainer.querySelectorAll('a[href^="#"], a[href^="./"], a[href^="../"]');
+        links.forEach(link => {
+            const href = link.getAttribute('href');
+            if (href.startsWith('#')) {
+                // Convert anchor links to point to kitzy.com
+                link.setAttribute('href', `https://kitzy.com/${href}`);
+            } else if (href.startsWith('./') || href.startsWith('../')) {
+                // Convert relative links to point to source repo
+                link.setAttribute('href', `https://github.com/kitzy/kitzy/blob/main/${href}`);
+            }
+        });
+        
+        console.log('External About content loaded successfully');
+        
+    } catch (error) {
+        console.error('Error loading external About content:', error);
+        
+        // Fallback: show message about using local content
+        aboutContainer.innerHTML = `
+            <div class="external-content-error">
+                <p><em>Loading content from source repository...</em></p>
+                <p>If content doesn't appear, showing local version:</p>
+            </div>
+        `;
+        
+        // After a short delay, show the local fallback content
+        setTimeout(() => {
+            aboutContainer.innerHTML = `
+                <h1>Hi, I'm Kitzy 👋</h1>
+                
+                <p><strong>Customer Support Engineer at <a href="https://github.com/fleetdm">@fleetdm</a> | Infrastructure Nerd | Dog & Motorcycle Lover</strong></p>
+                
+                <hr>
+                
+                <h3>👨‍💻 About Me</h3>
+                
+                <ul>
+                    <li>🏳️‍⚧️ Pronouns: they/them/theirs or she/her/hers (either is equally fine)</li>
+                    <li>🏆 Over 15 years in endpoint management & IT engineering</li>
+                    <li>🛠️ Previously Sr. IT Engineering Manager at Fastly and Professional Services Engineer at Jamf</li>
+                    <li>🍏 Got my start at Apple Retail, configuring demo systems and imaging devices</li>
+                    <li>🌍 Passionate about infrastructure, automation, and making IT work smarter</li>
+                    <li>📖 Curious how I work best? Check out my <a href="/readme/">personal user manual</a></li>
+                </ul>
+            `;
+        }, 3000);
+    }
+}
+
+// Load external content when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadExternalAboutContent);
+} else {
+    loadExternalAboutContent();
+}

--- a/index.md
+++ b/index.md
@@ -5,21 +5,7 @@ description: "Customer Support Engineer at Fleet | Infrastructure Nerd | Dog & M
 ---
 
 <div class="markdown-content">
-    <!-- About content will be loaded here. For now, using a simple version -->
-    <h1>Hi, I'm Kitzy 👋</h1>
-    
-    <p><strong>Customer Support Engineer at <a href="https://github.com/fleetdm">@fleetdm</a> | Infrastructure Nerd | Dog & Motorcycle Lover</strong></p>
-    
-    <hr>
-    
-    <h3>👨‍💻 About Me</h3>
-    
-    <ul>
-        <li>🏳️‍⚧️ Pronouns: they/them/theirs or she/her/hers (either is equally fine)</li>
-        <li>🏆 Over 15 years in endpoint management & IT engineering</li>
-        <li>🛠️ Previously Sr. IT Engineering Manager at Fastly and Professional Services Engineer at Jamf</li>
-        <li>🍏 Got my start at Apple Retail, configuring demo systems and imaging devices</li>
-        <li>🌍 Passionate about infrastructure, automation, and making IT work smarter</li>
-        <li>📖 Curious how I work best? Check out my <a href="{{ '/readme/' | relative_url }}">personal user manual</a></li>
-    </ul>
+    <div id="external-about-content">
+        <div class="loading-external">Loading content from source repository...</div>
+    </div>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -910,3 +910,28 @@ body {
 ::-webkit-scrollbar-thumb:hover {
     background: #484f58;
 }
+
+/* External content loading states */
+.loading-external {
+    color: #7d8590;
+    font-style: italic;
+    padding: 20px 0;
+    text-align: center;
+}
+
+.external-content-error {
+    color: #f78166;
+    background: rgba(248, 81, 73, 0.1);
+    border: 1px solid rgba(248, 81, 73, 0.2);
+    border-radius: 6px;
+    padding: 16px;
+    margin: 16px 0;
+}
+
+.external-content-error p {
+    margin-bottom: 8px;
+}
+
+.external-content-error p:last-child {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
🔗 **Implement single source of truth for About content**

## Problem:
Content drift between  About page and  README.md meant maintaining duplicate content in two places.

## Solution:
- **Dynamic content loading**: JavaScript fetches README.md from  repo via GitHub API
- **Real-time updates**: About page always shows latest content from source repository
- **Graceful fallbacks**: Local content displays if GitHub API unavailable
- **Markdown processing**: Uses existing marked.js to convert markdown to HTML

## Technical Implementation:
✅ **Created **: Fetches content from GitHub API  
✅ **Updated About page**: Now uses dynamic content container  
✅ **Added to layout**: Included script in default template  
✅ **Added CSS styling**: Loading states and error handling  
✅ **Link correction**: Fixes relative links to point to source repo  

## Benefits:
- **No content drift**: Single source of truth in  README
- **Always up-to-date**: Changes in source repo appear immediately
- **Reliable fallback**: Shows local content if API fails
- **Same pattern**: Consistent with existing GitHub integration approach

## How it works:
1. Page loads with "Loading content..." message
2. JavaScript fetches README.md from  via GitHub API
3. Content is decoded from base64 and converted from markdown to HTML
4. Relative links are corrected to point to source repo or kitzy.com
5. If API fails, fallback content displays after 3 seconds

Now you can update your About content in one place ( repo) and it will appear on both GitHub profile and personal website! 🎉