### PR TITLE
Remove tags display from blog page

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -25,14 +25,6 @@ permalink: /blog/
                     {% else %}
                         <p>{{ post.excerpt | strip_html | truncate: 200 }}</p>
                     {% endif %}
-                    
-                    {% if post.tags %}
-                        <div class="post-tags">
-                            {% for tag in post.tags %}
-                                <span class="tag">{{ tag }}</span>
-                            {% endfor %}
-                        </div>
-                    {% endif %}
                 </article>
             {% endfor %}
         </div>


### PR DESCRIPTION
🏷️ **Clean up blog page by removing tag display**

## Change:
Removed the highlighted tag display from blog post previews that was showing words like "fleet work culture remote-work" in highlighted boxes.

## Why:
- **Cleaner appearance**: Blog page looks less cluttered without the tag boxes
- **Better focus**: Draws attention to post titles and descriptions
- **Flexible for future**: Tags remain in post frontmatter and can be re-enabled later

## What's removed:
- Post tags display section from blog page template
- The highlighted tag boxes that appeared under each post preview

## What's preserved:
- ✅ Tags still exist in post frontmatter ()
- ✅ Can easily re-enable tag display when more posts are added
- ✅ Tags can be used for future features like filtering or search

## Result:
Blog page now shows clean post previews with just titles, dates, and descriptions - no more highlighted tag boxes cluttering the layout.

Perfect for keeping things simple while you build up your blog content! 📝