### PR TITLE
Add comprehensive debugging for GitHub language detection

### DIFF
--- a/assets/js/github-integration.js
+++ b/assets/js/github-integration.js
@@ -26,19 +26,36 @@ async function loadGitHubData() {
 
         console.log(`Loaded ${repos.length} repositories and ${orgs.length} organizations`);
 
+        // Debug: Log all repositories and their languages
+        console.log('All repositories:');
+        repos.forEach(repo => {
+            console.log(`- ${repo.name}: ${repo.language || 'No language'} (fork: ${repo.fork}, stars: ${repo.stargazers_count})`);
+        });
+
         // Calculate top languages from repositories
         const languages = {};
+        let processedRepos = 0;
+        
         repos.forEach(repo => {
             if (repo.language && !repo.fork) { // Only count non-forked repos
                 languages[repo.language] = (languages[repo.language] || 0) + repo.stargazers_count + 1;
+                processedRepos++;
+                console.log(`Added ${repo.language} from ${repo.name} (score: ${repo.stargazers_count + 1})`);
             }
         });
 
+        console.log(`Processed ${processedRepos} repositories with languages`);
+        console.log('Language counts:', languages);
+
         // Get top 6 languages sorted by usage (stars + count)
-        const topLanguages = Object.entries(languages)
-            .sort(([,a], [,b]) => b - a)
-            .slice(0, 6)
-            .map(([lang]) => lang);
+        const languageEntries = Object.entries(languages);
+        console.log('Language entries before sorting:', languageEntries);
+        
+        const sortedLanguages = languageEntries.sort(([,a], [,b]) => b - a);
+        console.log('Sorted languages:', sortedLanguages);
+        
+        const topLanguages = sortedLanguages.slice(0, 6).map(([lang]) => lang);
+        console.log('Top 6 languages:', topLanguages);
 
         // Update languages in sidebar
         const languagesContainer = document.getElementById('github-languages');


### PR DESCRIPTION
🔍 **Debug why only 3 languages showing instead of expected 6**

## Problem:
The sidebar should display top 6 programming languages from GitHub repos, but only showing 3 (Shell, Python, HCL).

## Debugging Added:
✅ **Repository logging**: Shows all repos and their detected languages  
✅ **Processing details**: Which repos are included vs filtered out (forks, no language)  
✅ **Language counting**: How each language score is calculated  
✅ **Sorting process**: Language ranking and selection logic  
✅ **Final results**: What the top 6 selection process produces  

## Expected Console Output:
- List of all repositories with language detection status
- Count of repositories actually processed for languages
- Language scores and ranking
- Final top 6 language selection

## Investigation Goals:
1. **Repository count**: How many repos have languages detected?
2. **Fork filtering**: Are we excluding too many repositories?
3. **Language diversity**: Does the user actually have 6+ different languages?
4. **API limitations**: Is GitHub API returning all repositories?

## Next Steps:
After reviewing console output, we can:
- Adjust filtering logic if needed
- Include different repository types
- Modify scoring algorithm
- Add manual language additions if GitHub detection is limited

This will help identify the root cause of the limited language display! 🔧