### PR TITLE
Style projects page to match GitHub pinned repos

### DIFF
--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -5,11 +5,16 @@ description: "My open source projects and contributions"
 permalink: /projects/
 ---
 
-<div class="markdown-content">
-    <h2>Projects</h2>
-    <p>Here are some of my featured open source projects and contributions:</p>
-    
-    <div id="featured-projects">
-        <div class="loading-projects">Loading projects...</div>
-    </div>
+---
+layout: default
+title: Projects
+permalink: /projects/
+---
+
+# Projects
+
+Here are some of my featured open source projects and contributions:
+
+<div class="projects-grid" id="projects-container">
+    <div class="loading-projects">Loading projects...</div>
 </div>

--- a/assets/js/projects.js
+++ b/assets/js/projects.js
@@ -32,40 +32,46 @@ async function loadFeaturedProjects() {
         const repos = await Promise.all(repoPromises);
         console.log('Loaded featured projects:', repos);
         
-        // Generate HTML for each project
+        // Generate HTML for each project (GitHub pinned repos style)
         const projectsHTML = repos.map(repo => {
             const languageHTML = repo.language ? 
-                `<span class="project-language">${repo.language}</span>` : '';
+                `<span class="repo-language">
+                    <span class="language-color" data-language="${repo.language.toLowerCase()}"></span>
+                    ${repo.language}
+                </span>` : '';
             
             const starsHTML = repo.stargazers_count > 0 ? 
-                `<span class="project-stars">⭐ ${repo.stargazers_count}</span>` : '';
+                `<span class="repo-stat">
+                    <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16">
+                        <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"></path>
+                    </svg>
+                    ${repo.stargazers_count}
+                </span>` : '';
             
             const forksHTML = repo.forks_count > 0 ? 
-                `<span class="project-forks">🍴 ${repo.forks_count}</span>` : '';
-            
-            const topicsHTML = repo.topics && repo.topics.length > 0 ? 
-                `<div class="project-topics">
-                    ${repo.topics.map(topic => `<span class="project-topic">${topic}</span>`).join('')}
-                </div>` : '';
+                `<span class="repo-stat">
+                    <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16">
+                        <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"></path>
+                    </svg>
+                    ${repo.forks_count}
+                </span>` : '';
             
             return `
-                <div class="project-card">
-                    <div class="project-header">
-                        <h3><a href="${repo.html_url}" target="_blank" rel="noopener">${repo.name}</a></h3>
-                        <div class="project-meta">
-                            ${languageHTML}
-                            ${starsHTML}
-                            ${forksHTML}
-                        </div>
+                <div class="pinned-repo">
+                    <div class="pinned-repo-header">
+                        <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16">
+                            <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
+                        </svg>
+                        <a href="${repo.html_url}" target="_blank" rel="noopener" class="repo-name">${repo.name}</a>
+                        <span class="repo-visibility">Public</span>
                     </div>
                     
-                    ${repo.description ? `<p class="project-description">${repo.description}</p>` : ''}
+                    ${repo.description ? `<p class="repo-description">${repo.description}</p>` : ''}
                     
-                    ${topicsHTML}
-                    
-                    <div class="project-links">
-                        <a href="${repo.html_url}" target="_blank" rel="noopener" class="project-link">View Repository</a>
-                        ${repo.homepage ? `<a href="${repo.homepage}" target="_blank" rel="noopener" class="project-link">Live Demo</a>` : ''}
+                    <div class="repo-footer">
+                        ${languageHTML}
+                        ${starsHTML}
+                        ${forksHTML}
                     </div>
                 </div>
             `;

--- a/styles.css
+++ b/styles.css
@@ -953,126 +953,119 @@ body {
     margin: 16px 0;
 }
 
-.project-card {
-    background: #161b22;
+/* GitHub Pinned Repos Style */
+.pinned-repo {
     border: 1px solid #30363d;
     border-radius: 6px;
-    padding: 20px;
-    margin-bottom: 20px;
-    transition: border-color 0.2s ease;
+    padding: 16px;
+    margin-bottom: 16px;
+    background-color: #0d1117;
+    transition: border-color 0.15s ease-in-out;
 }
 
-.project-card:hover {
+.pinned-repo:hover {
     border-color: #58a6ff;
 }
 
-.project-header {
+.pinned-repo-header {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-bottom: 12px;
-    flex-wrap: wrap;
-    gap: 12px;
+    align-items: center;
+    margin-bottom: 8px;
 }
 
-.project-header h3 {
-    margin: 0;
-    flex: 1;
-    min-width: 200px;
+.repo-icon {
+    fill: #7d8590;
+    margin-right: 8px;
+    flex-shrink: 0;
 }
 
-.project-header h3 a {
+.repo-name {
+    font-weight: 600;
     color: #58a6ff;
     text-decoration: none;
-    font-size: 1.2em;
+    font-size: 14px;
+    margin-right: 8px;
 }
 
-.project-header h3 a:hover {
+.repo-name:hover {
     text-decoration: underline;
 }
 
-.project-meta {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    flex-wrap: wrap;
-}
-
-.project-language {
-    background: #21262d;
-    color: #58a6ff;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 0.85em;
+.repo-visibility {
     border: 1px solid #30363d;
+    border-radius: 2em;
+    padding: 0 7px;
+    font-size: 12px;
+    color: #7d8590;
+    font-weight: 500;
+    line-height: 18px;
 }
 
-.project-stars, .project-forks {
+.repo-description {
+    color: #8b949e;
+    font-size: 12px;
+    margin: 0 0 8px 0;
+    line-height: 1.5;
+}
+
+.repo-footer {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-size: 12px;
     color: #7d8590;
-    font-size: 0.9em;
+}
+
+.repo-language {
     display: flex;
     align-items: center;
     gap: 4px;
 }
 
-.project-description {
-    color: #e6edf3;
-    margin: 12px 0;
-    line-height: 1.5;
+.language-color {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
 }
 
-.project-topics {
+.repo-stat {
     display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    margin: 12px 0;
+    align-items: center;
+    gap: 4px;
+    color: #7d8590;
 }
 
-.project-topic {
-    background: #0969da;
-    color: #ffffff;
-    padding: 2px 8px;
-    border-radius: 12px;
-    font-size: 0.75em;
-    text-transform: lowercase;
+.repo-stat .repo-icon {
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
 }
 
-.project-links {
-    display: flex;
-    gap: 12px;
-    margin-top: 16px;
-    flex-wrap: wrap;
-}
+/* Language colors matching GitHub */
+.language-color[data-language="shell"] { background-color: #89e051; }
+.language-color[data-language="python"] { background-color: #3572A5; }
+.language-color[data-language="go"] { background-color: #00ADD8; }
+.language-color[data-language="hcl"] { background-color: #844FBA; }
+.language-color[data-language="javascript"] { background-color: #f1e05a; }
+.language-color[data-language="typescript"] { background-color: #2b7489; }
+.language-color[data-language="dockerfile"] { background-color: #384d54; }
 
-.project-link {
-    background: #21262d;
-    color: #e6edf3;
-    border: 1px solid #30363d;
-    border-radius: 6px;
-    padding: 8px 16px;
-    text-decoration: none;
-    font-size: 0.9em;
-    transition: all 0.2s ease;
-}
-
-.project-link:hover {
-    background: #30363d;
-    border-color: #58a6ff;
-    color: #58a6ff;
+/* Projects grid */
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
 }
 
 /* Responsive design for projects */
 @media (max-width: 768px) {
-    .project-header {
-        flex-direction: column;
-        align-items: stretch;
+    .projects-grid {
+        grid-template-columns: 1fr;
     }
     
-    .project-meta {
-        justify-content: flex-start;
-    }
-    
-    .project-links {
-        flex-direction: column;
+    .pinned-repo {
+        padding: 12px;
     }
 }


### PR DESCRIPTION
Updates the projects page to have the same look and feel as GitHub's pinned repositories section:

- **Compact cards** with GitHub's exact styling and spacing
- **Repository icons** and proper visual hierarchy 
- **Language color dots** matching GitHub's official colors
- **Star and fork counts** with authentic GitHub SVG icons
- **Clean typography** matching GitHub's font sizes and weights
- **Responsive grid layout** for optimal viewing on all devices
- **Simplified design** removing verbose topics and links for a cleaner look

This creates a much more professional and familiar appearance that matches what users expect from GitHub's interface.