### PR TITLE
Fix projects page loading issue

### DIFF
--- a/assets/js/projects.js
+++ b/assets/js/projects.js
@@ -4,7 +4,7 @@
  */
 
 async function loadFeaturedProjects() {
-    const projectsContainer = document.getElementById('featured-projects');
+    const projectsContainer = document.getElementById('projects-container');
     
     if (!projectsContainer) {
         return; // Only run on projects page
@@ -77,7 +77,7 @@ async function loadFeaturedProjects() {
             `;
         }).join('');
         
-        // Update the container with projects
+        // Update the container with the projects
         projectsContainer.innerHTML = projectsHTML;
         
         console.log('Featured projects loaded successfully');


### PR DESCRIPTION
Fixes the JavaScript container ID mismatch that was causing the projects page to get stuck on 'Loading projects...'.

**Problem**: The projects.js was looking for an element with ID 'featured-projects' but the HTML page has 'projects-container'.

**Solution**: Updated the JavaScript to use the correct container ID.

This should immediately fix the broken projects page and display the GitHub-style pinned repositories.