### PR TITLE
Fix duplicate front matter artifact

### DIFF
--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -5,12 +5,6 @@ description: "My open source projects and contributions"
 permalink: /projects/
 ---
 
----
-layout: default
-title: Projects
-permalink: /projects/
----
-
 # Projects
 
 Here are some of my featured open source projects and contributions:


### PR DESCRIPTION
Removes the duplicate Jekyll front matter block that was causing unwanted text to appear at the top of the projects page.

**Problem**: The projects page had two front matter blocks, causing the second one to be rendered as visible content showing 'layout: default title: Projects permalink: /projects/ —'

**Solution**: Removed the duplicate front matter block while keeping the proper metadata.

This will clean up the projects page display.