### PR TITLE
Update projects page description to remove "open source" reference

### DIFF
--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: Projects
-description: "My open source projects and contributions"
+description: "My projects and contributions"
 permalink: /projects/
 ---
 
 # Projects
 
-Here are some of my featured open source projects and contributions:
+Here are some of my featured projects and contributions
 
 <div class="projects-grid" id="projects-container">
     <div class="loading-projects">Loading projects...</div>


### PR DESCRIPTION
Revise the projects page description to eliminate the "open source" terminology for clarity.