### PR TITLE
Fix README page loading error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,6 @@ collections:
 
 # Exclude files
 exclude:
-  - README.md
   - Gemfile
   - Gemfile.lock
   - node_modules

--- a/assets/js/readme-loader.js
+++ b/assets/js/readme-loader.js
@@ -13,8 +13,15 @@ async function loadReadmeContent() {
     try {
         console.log('Loading README.md content...');
         
-        // Fetch the raw README.md from the repository
-        const response = await fetch('https://raw.githubusercontent.com/kitzy/kitzy.github.io/main/README.md');
+        // Try fetching from relative path first, then fallback to GitHub raw
+        let response;
+        try {
+            response = await fetch('/README.md');
+            if (!response.ok) throw new Error('Local fetch failed');
+        } catch (localError) {
+            console.log('Local fetch failed, trying GitHub raw URL...');
+            response = await fetch('https://raw.githubusercontent.com/kitzy/kitzy.github.io/main/README.md');
+        }
         
         if (!response.ok) {
             throw new Error(`Failed to fetch README.md: ${response.status}`);


### PR DESCRIPTION
Fixes the 'Unable to load README.md' error that was preventing the dynamic README page from working.

## Problem
The README page was showing an error because Jekyll was excluding the README.md file from being served as a static asset.

## Solution
- **Removed README.md from Jekyll exclude list** - This allows Jekyll to serve the file at 
- **Added fallback fetch strategy** - Tries local path first, then GitHub raw URL as fallback
- **Improved error handling** - Better logging for debugging fetch issues

## Result
- ✅ README page now loads content dynamically from the root README.md file
- ✅ Single source of truth - only need to edit the root README.md file
- ✅ Automatic markdown-to-HTML conversion using marked.js
- ✅ Graceful fallbacks if anything fails

This restores the intended functionality where you can edit just the README.md file and it automatically appears on your /readme/ page.