### PR TITLE
Add experimental Fleet AutoPkg processor documentation for v4.74.0

### DIFF
--- a/_posts/2025-09-20-experimental-fleet-autoplg-processor-ready-for-fleet-v4.74.0.md
+++ b/_posts/2025-09-20-experimental-fleet-autoplg-processor-ready-for-fleet-v4.74.0.md
@@ -1,22 +1,22 @@
 ---
 layout: post
-title: "My experimental Fleet AutoPkg processor is ready for Fleet v4.73.0 gitops YAML changes"
-description: "Fleet v4.73.0 will introduce breaking changes to gitops YAML. My experimental Fleet autopkg processor is already updated to handle the new schema, automatically detecting your server version via the Fleet API and outputting the correct format, no recipe changes needed."
+title: "My experimental Fleet AutoPkg processor is ready for Fleet v4.74.0 gitops YAML changes"
+description: "Fleet v4.74.0 will introduce breaking changes to gitops YAML. My experimental Fleet autopkg processor is already updated to handle the new schema, automatically detecting your server version via the Fleet API and outputting the correct format, no recipe changes needed."
 date: 2025-09-20
 tags: [fleet, autopkg, projects, experiments]
 ---
 
-Breaking changes aren’t fun, but sometimes they’re necessary. Fleet v4.73.0 will change how `gitops` YAML is structured, so anything that writes those files will need to adapt.
+Breaking changes aren’t fun, but sometimes they’re necessary. Fleet v4.74.0 will change how `gitops` YAML is structured, so anything that writes those files will need to adapt.
 
-I’ve been tinkering with an [experimental Fleet autopkg processor](https://github.com/kitzy/fleet-autopkg-recipes) that ties [autopkg](https://github.com/autopkg/autopkg) into Fleet. I’ve already updated the processor so it understands the new schema that’s coming in Fleet v4.73.0.  
+I’ve been tinkering with an [experimental Fleet autopkg processor](https://github.com/kitzy/fleet-autopkg-recipes) that ties [autopkg](https://github.com/autopkg/autopkg) into Fleet. I’ve already updated the processor so it understands the new schema that’s coming in Fleet v4.74.0.  
 
 It’s still experimental and not in active use anywhere (as far as I know), but it’s now in a good place if you want to kick the tires — and it’s ready ahead of the breaking changes in Fleet.
 
 ## What’s changing in Fleet
 
-Starting in Fleet v4.73.0, `gitops` YAML will move to a new format. That could break tools that assume the old structure.
+Starting in Fleet v4.74.0, `gitops` YAML will move to a new format. That could break tools that assume the old structure.
 
-Here’s the important part for this project: **your autopkg recipes will not need to change.** The processor is the piece that adapts, not the recipes. If you were hand-rolling YAML elsewhere, that code would need attention, but the recipes here can stay as they are. Details are in the [issue thread](https://github.com/kitzy/fleet-autopkg-recipes/issues/13).
+Here’s the important part for this project: **existing autopkg recipes will not need to change.** The processor is the piece that adapts, not the recipes. If you were hand-rolling YAML elsewhere, that code would need attention, but the recipes here can stay as they are. Details are in the [issue thread](https://github.com/kitzy/fleet-autopkg-recipes/issues/13).
 
 ## How the processor now works
 
@@ -24,8 +24,8 @@ The export step writes YAML that matches the server’s expected schema. Instead
 
 - **Recipes stay the same.** The processor takes their outputs and writes the right YAML shape.  
 - **Version detection built in.** It queries the Fleet API to learn the server version, then chooses the correct YAML format.  
-- **New schema supported.** When the server is v4.73.0 or later, it emits the new `gitops` YAML.  
-- **Backwards compatibility.** When the server is older than v4.73.0, it emits the legacy format.  
+- **New schema supported.** When the server is v4.74.0 or later, it emits the new `gitops` YAML.  
+- **Backwards compatibility.** When the server is older than v4.74.0, it emits the legacy format.  
 - **Modular exporter.** If the schema changes again, it should be straightforward to extend.  
 
 For more information, please see the [implementation summary](https://github.com/kitzy/fleet-autopkg-recipes/issues/13#issuecomment-3315146644).


### PR DESCRIPTION
Update documentation to reflect changes in the Fleet AutoPkg processor for compatibility with Fleet v4.74.0, ensuring users are informed about the new schema and version detection features.