### PR TITLE
Add GitHub token support for private repos

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,5 +46,6 @@
     <script src="{{ '/assets/js/projects.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/readme.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/readme-loader.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/github-token-setup.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/js/github-integration.js
+++ b/assets/js/github-integration.js
@@ -9,23 +9,62 @@ async function loadGitHubData() {
     try {
         console.log('Loading GitHub data for', username);
         
-        // Fetch user data, repositories, and organizations
+        // Check for GitHub token (for private repos access)
+        const token = getGitHubToken();
+        const headers = token ? { 'Authorization': `token ${token}` } : {};
+        
+        console.log('Using GitHub token:', token ? 'Yes (private repos included)' : 'No (public repos only)');
+        
+        // Fetch user data, repositories (including private if token provided), and organizations
         const [userResponse, reposResponse, orgsResponse] = await Promise.all([
-            fetch(`https://api.github.com/users/${username}`),
-            fetch(`https://api.github.com/users/${username}/repos?per_page=100&sort=updated&type=owner`),
-            fetch(`https://api.github.com/users/${username}/orgs`)
+            fetch(`https://api.github.com/users/${username}`, { headers }),
+            fetch(`https://api.github.com/user/repos?per_page=100&sort=updated&type=all&affiliation=owner`, { headers }),
+            fetch(`https://api.github.com/users/${username}/orgs`, { headers })
         ]);
 
         if (!userResponse.ok || !reposResponse.ok || !orgsResponse.ok) {
-            throw new Error('Failed to fetch GitHub data');
+            console.warn('Some GitHub API calls failed, falling back to public-only data');
+            
+            // Fallback to public-only endpoints if authenticated calls fail
+            const [fallbackReposResponse] = await Promise.all([
+                fetch(`https://api.github.com/users/${username}/repos?per_page=100&sort=updated&type=owner`)
+            ]);
+            
+            if (!userResponse.ok || !fallbackReposResponse.ok) {
+                throw new Error('Failed to fetch GitHub data');
+            }
+            
+            const user = await userResponse.json();
+            const repos = await fallbackReposResponse.json();
+            const orgs = orgsResponse.ok ? await orgsResponse.json() : [];
+            
+            processGitHubData(user, repos, orgs, false);
+        } else {
+            const user = await userResponse.json();
+            const repos = await reposResponse.json();
+            const orgs = await orgsResponse.json();
+            
+            processGitHubData(user, repos, orgs, token ? true : false);
         }
 
-        const user = await userResponse.json();
-        const repos = await reposResponse.json();
-        const orgs = await orgsResponse.json();
+    } catch (error) {
+        console.error('Error loading GitHub data:', error);
+        
+        // Fallback content on error
+        setFallbackContent();
+    }
+}
+
+function getGitHubToken() {
+    // Check for token in localStorage (set by user)
+    return localStorage.getItem('github_token');
+}
+
+function processGitHubData(user, repos, orgs, includesPrivateRepos) {
 
         console.log(`Loaded ${repos.length} repositories and ${orgs.length} organizations`);
         console.log('User data:', user);
+        console.log('Includes private repos:', includesPrivateRepos);
 
         // Update bio if available
         const bioContainer = document.getElementById('github-bio');
@@ -37,7 +76,7 @@ async function loadGitHubData() {
         // Debug: Log all repositories and their languages
         console.log('All repositories:');
         repos.forEach(repo => {
-            console.log(`- ${repo.name}: ${repo.language || 'No language'} (fork: ${repo.fork}, stars: ${repo.stargazers_count})`);
+            console.log(`- ${repo.name}: ${repo.language || 'No language'} (fork: ${repo.fork}, stars: ${repo.stargazers_count}, private: ${repo.private})`);
         });
 
         // Calculate top languages from repositories
@@ -45,10 +84,10 @@ async function loadGitHubData() {
         let processedRepos = 0;
         
         repos.forEach(repo => {
-            if (repo.language) { // Count all repos with languages (including forks)
+            if (repo.language) { // Count all repos with languages (including forks and private repos)
                 languages[repo.language] = (languages[repo.language] || 0) + repo.stargazers_count + 1;
                 processedRepos++;
-                console.log(`Added ${repo.language} from ${repo.name} (score: ${repo.stargazers_count + 1}, fork: ${repo.fork})`);
+                console.log(`Added ${repo.language} from ${repo.name} (score: ${repo.stargazers_count + 1}, fork: ${repo.fork}, private: ${repo.private})`);
             }
         });
 
@@ -106,10 +145,9 @@ async function loadGitHubData() {
         }
 
         console.log('GitHub data loaded successfully');
+}
 
-    } catch (error) {
-        console.error('Error loading GitHub data:', error);
-        
+function setFallbackContent() {
         // Fallback content on error
         const languagesContainer = document.getElementById('github-languages');
         if (languagesContainer) {
@@ -131,7 +169,6 @@ async function loadGitHubData() {
                 </a>
             `;
         }
-    }
 }
 
 // Load GitHub data when the DOM is ready

--- a/assets/js/github-token-setup.js
+++ b/assets/js/github-token-setup.js
@@ -1,0 +1,45 @@
+/**
+ * GitHub Token Setup Utility
+ * Simple helper to set/remove GitHub personal access token for private repo access
+ */
+
+function setupGitHubToken() {
+    const currentToken = localStorage.getItem('github_token');
+    
+    if (currentToken) {
+        const action = confirm('GitHub token is already set. Do you want to update it?');
+        if (!action) return;
+    }
+    
+    const token = prompt('Enter your GitHub Personal Access Token (it will be stored locally in your browser):');
+    
+    if (token && token.trim()) {
+        localStorage.setItem('github_token', token.trim());
+        alert('GitHub token saved! Refresh the page to see private repositories in your language stats.');
+    }
+}
+
+function removeGitHubToken() {
+    const confirmed = confirm('Are you sure you want to remove the GitHub token? This will exclude private repositories from language stats.');
+    
+    if (confirmed) {
+        localStorage.removeItem('github_token');
+        alert('GitHub token removed. Refresh the page to update.');
+    }
+}
+
+function checkGitHubToken() {
+    const token = localStorage.getItem('github_token');
+    
+    if (token) {
+        alert('GitHub token is set. Private repositories will be included in language stats.');
+    } else {
+        alert('No GitHub token set. Only public repositories will be included in language stats.');
+    }
+}
+
+// Add console helpers
+console.log('GitHub Token Setup Helpers:');
+console.log('- setupGitHubToken() - Set your GitHub token');
+console.log('- removeGitHubToken() - Remove the token');
+console.log('- checkGitHubToken() - Check if token is set');


### PR DESCRIPTION
Adds GitHub Personal Access Token support to include private repositories in language calculations.

## New Features
- **GitHub Token Authentication**: Supports optional GitHub token for accessing private repos
- **Enhanced Language Detection**: Now includes languages from private repositories  
- **Token Setup Utility**: Helper script to guide token creation and setup
- **Graceful Fallback**: Still works without token, just uses public repos

## How It Works
1. Checks for GitHub token in localStorage
2. If token exists, uses authenticated API calls to access all repos (public + private)
3. If no token, falls back to public-only repos (current behavior)
4. Includes setup utility at  for easy token configuration

## Security
- Token stored only in browser localStorage (never sent to your server)
- Only requires 'repo' scope for repository access
- Can be removed/regenerated anytime

## Next Steps
After merging, visit  to create and configure your GitHub token.