### PR TITLE
Fix GitHub secret name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ github_username: kitzy
 repository: kitzy/kitzy.github.io
 
 # GitHub token for build-time language calculation (set in environment)
-# Set GITHUB_TOKEN_LANGUAGES in your build environment for private repo access
+# Set PERSONAL_GITHUB_TOKEN in your build environment for private repo access
 
 # Build settings
 markdown: kramdown

--- a/_plugins/github_languages.rb
+++ b/_plugins/github_languages.rb
@@ -11,11 +11,11 @@ module Jekyll
       puts "🔍 GitHubLanguagesGenerator: Starting language data generation..."
       
       # Get GitHub token from environment variable
-      token = ENV['GITHUB_TOKEN_LANGUAGES']
+      token = ENV['PERSONAL_GITHUB_TOKEN']
       username = site.config['github_username'] || 'kitzy'
       
       if token.nil? || token.empty?
-        puts "⚠️  No GITHUB_TOKEN_LANGUAGES found, using fallback data"
+        puts "⚠️  No PERSONAL_GITHUB_TOKEN found, using fallback data"
         generate_fallback_data(site)
         return
       end


### PR DESCRIPTION
Fixes the GitHub secret name to avoid the reserved GITHUB_ prefix.

## Problem
GitHub reserves secret names that start with , so  is not allowed.

## Solution
- Changed to  (allowed name)
- Updated plugin code to use new environment variable
- Updated documentation in config file

## Setup Required
Create repository secret named  with your GitHub personal access token (repo scope).