### PR TITLE
Add GitHub Sponsors call-to-action and badge to About page and bio section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # README.md
 
 _updated: September 23, 2025_
@@ -115,4 +114,4 @@ These are the principles that guide how I see the world and how I show up at wor
 - Ambiguity and unclear expectations (my brain fills in the blanks with chaos)  
 - Endless repetitive tasks  
 - Being taken for granted when I’ve overextended  
-- Feeling like I have to “mask” my quirks  
+- Feeling like I have to “mask” my quirks

--- a/assets/js/external-content.js
+++ b/assets/js/external-content.js
@@ -43,6 +43,21 @@ async function loadExternalAboutContent() {
         // Update the container with fetched content
         aboutContainer.innerHTML = htmlContent;
         
+        // Add GitHub Sponsors CTA after the main content
+        const sponsorCTA = document.createElement('div');
+        sponsorCTA.className = 'sponsor-cta';
+        sponsorCTA.innerHTML = `
+            <hr>
+            <h3>💖 Support My Work</h3>
+            <p>If you enjoy my content and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
+            <p>
+                <a href="https://github.com/sponsors/kitzy" target="_blank">
+                    <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" />
+                </a>
+            </p>
+        `;
+        aboutContainer.appendChild(sponsorCTA);
+        
         // Fix specific link - the README link should point to the /readme/ page
         const readmeLinks = aboutContainer.querySelectorAll('a[href*="README"]');
         readmeLinks.forEach(link => {
@@ -79,6 +94,18 @@ async function loadExternalAboutContent() {
                 <li>🌍 Passionate about infrastructure, automation, and making IT work smarter</li>
                 <li>📖 Curious how I work best? Check out my <a href="/readme/">personal user manual</a></li>
             </ul>
+            
+            <hr>
+            
+            <h3>💖 Support My Work</h3>
+            
+            <p>If you enjoy my content and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
+            
+            <p>
+                <a href="https://github.com/sponsors/kitzy" target="_blank">
+                    <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" />
+                </a>
+            </p>
         `;
     }
 }

--- a/assets/js/github-integration.js
+++ b/assets/js/github-integration.js
@@ -120,9 +120,38 @@ async function loadBioFromAPI(username) {
     // Update bio if available
     const bioContainer = document.getElementById('github-bio');
     if (bioContainer && user.bio) {
-        bioContainer.textContent = user.bio;
-        console.log('Updated bio:', user.bio);
+        // Remove @fleetdm from bio and add sponsors badge
+        let cleanBio = user.bio.replace(/@fleetdm/g, '').replace(/\s+/g, ' ').trim();
+        bioContainer.textContent = cleanBio;
+        
+        // Add sponsors badge after bio
+        addSponsorsBadge(bioContainer);
+        
+        console.log('Updated bio:', cleanBio);
     }
+}
+
+function addSponsorsBadge(bioContainer) {
+    // Remove any existing sponsors badge
+    const existingBadge = document.querySelector('.sponsors-badge-container');
+    if (existingBadge) {
+        existingBadge.remove();
+    }
+    
+    // Create sponsors badge container
+    const sponsorsBadge = document.createElement('div');
+    sponsorsBadge.className = 'sponsors-badge-container';
+    sponsorsBadge.style.marginTop = '10px';
+    sponsorsBadge.innerHTML = `
+        <a href="https://github.com/sponsors/kitzy" target="_blank">
+            <img src="https://img.shields.io/github/sponsors/kitzy?style=flat&logo=github&logoColor=white&labelColor=gray&color=pink" 
+                 alt="GitHub Sponsors" 
+                 style="max-width: 100%; height: auto;" />
+        </a>
+    `;
+    
+    // Insert after the bio container
+    bioContainer.parentNode.insertBefore(sponsorsBadge, bioContainer.nextSibling);
 }
 
 function updateLanguagesDisplay(languages) {
@@ -143,6 +172,7 @@ function updateLanguagesDisplay(languages) {
 function setFallbackContent() {
     setFallbackLanguages();
     setFallbackOrganizations();
+    setFallbackBio();
 }
 
 function setFallbackLanguages() {
@@ -169,6 +199,19 @@ function setFallbackOrganizations() {
                 <img src="https://avatars.githubusercontent.com/u/65584068?s=40&v=4" alt="Fleet" class="sidebar-org-icon">
             </a>
         `;
+    }
+}
+
+function setFallbackBio() {
+    const bioContainer = document.getElementById('github-bio');
+    if (bioContainer) {
+        // Set fallback bio without @fleetdm mention
+        bioContainer.textContent = 'Customer Support Engineer | Infrastructure Nerd | Dog & Motorcycle Lover';
+        
+        // Add sponsors badge
+        addSponsorsBadge(bioContainer);
+        
+        console.log('✅ Fallback bio and sponsors badge set successfully');
     }
 }
 


### PR DESCRIPTION
Introduce a call-to-action for GitHub Sponsors on the About page and integrate a sponsors badge into the bio section. This enhances visibility for support opportunities while maintaining a clean presentation.