### PR TITLE
Add GitHub Sponsors call-to-action to post layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,4 +18,15 @@ layout: default
     {% endif %}
     
     {{ content }}
+    
+    <!-- GitHub Sponsors CTA -->
+    <div class="sponsors-cta" style="margin-top: 40px; padding: 20px; border: 1px solid #30363d; border-radius: 8px; background: #0d1117;">
+        <h3 style="margin-top: 0; color: #e6edf3;">💖 Support My Work</h3>
+        <p style="color: #c9d1d9;">If you enjoyed this post and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank" style="color: #58a6ff;">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
+        <p style="margin-bottom: 0;">
+            <a href="https://github.com/sponsors/kitzy" target="_blank">
+                <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" style="max-width: 100%; height: auto;" />
+            </a>
+        </p>
+    </div>
 </div>


### PR DESCRIPTION
Introduce a call-to-action for GitHub Sponsors in the post layout to encourage support for blogging and open-source work.