### PR TITLE
Add a new post on transitioning from expertise to curiosity in career growth

### DIFF
--- a/_posts/2025-09-25-losing-nine-years-of-answers-to-find-better-questions.md
+++ b/_posts/2025-09-25-losing-nine-years-of-answers-to-find-better-questions.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title: "Losing nine years of answers to find better questions"
+description: "Leaving behind nearly a decade of institutional knowledge means trading expertise for curiosity. This post explores the discomfort and growth that comes from no longer being the one with all the answers."
+date: 2025-09-25
+tags: [career growth, workplace culture, professional identity, institutional knowledge]
+---
+
+I worked at my last company for just shy of nine years. In the end, I was the person who knew where all the ghosts were buried. I could tell you not just how a system worked, but why it worked that way. I had the lore. I carried the oral history of every weird decision, half-forgotten workaround, and obscure bit of technical trivia. For the last four years, I was the longest-tenured person in my department. If something didn’t make sense, chances were good I had the backstory. People came to me like a human footnote section.  
+
+There’s a certain pride in being that person. You feel indispensable. You feel like the company is woven into your bones. But there’s a trap hiding in that pride too. When you’re the one with all the answers, you risk slipping into career stagnation. You stop being challenged to learn new things because the challenge has shifted to everyone else. The questions dry up, and with them, so does the pressure to keep growing. It becomes easy to confuse institutional memory with personal worth, and harder to notice when your own learning has stalled.  
+
+Now, in my new role, I’m on the other side. I’m the new kid. No nine years of trivia. No encyclopedia of half-remembered decisions. When someone mentions a system or a policy, I don’t know the backstory. I just nod, take notes, and try to keep up. Instead of having the answers, I’m learning the questions.  
+
+It’s uncomfortable.  
+
+It turns out I had gotten very used to the feeling of expertise. I had built my whole rhythm around being the one people came to when they were stumped. Now, I’m the one raising my hand to ask “dumb” questions. It’s humbling to be reminded that “dumb” questions are never actually dumb. They’re the scaffolding of learning.  
+
+What I’ve been sitting with lately is how much of a shift it really is to no longer carry institutional knowledge. On one hand, I miss the confidence of knowing the hidden corners. On the other hand, there’s a kind of freedom in being unburdened by history. I don’t have to defend why something is the way it is, or remember which battle scar led to which policy. I get to experience things fresh, without dragging nine years of context behind me.  
+
+And maybe that’s the gift of being new. I can see things as they are, not as the fossil record of decisions made under pressures long gone. I can question whether a process makes sense now, instead of just reciting the reason it made sense five years ago.  
+
+It also forces me to rely on people instead of memory. At my old job, I could go weeks without needing to ask for help because the answers were already in my head. Now, I’m in constant conversation. I’m learning who to go to for what. I’m building a map of people instead of a map of dusty processes. That’s a shift too, and a healthy one.  
+
+The bigger lesson here is about identity. We all attach ourselves to certain roles we play: the reliable one, the idea person, the encyclopedia. It feels good to be needed, and over time, it can start to feel like that role is who we are. Stepping out of it, I’m reminded that I’m more than the sum of the knowledge I carried at one job. I’m still me, even without the lore.  
+
+If anything, losing that institutional knowledge has forced me to lean back into curiosity. To admit I don’t know, and to enjoy the act of learning again. To rediscover the energy that comes from being a beginner instead of an expert. There’s vulnerability in that, but also growth.  
+
+I won’t pretend it’s easy. Some days I miss being the person with the answers. Some days I bristle at not knowing what everyone else takes for granted. But little by little, I’m getting comfortable with being uncomfortable. I’m trusting that the encyclopedia will rebuild itself in time. In the meantime, I’m learning to listen more, ask better questions, and notice what’s actually happening in the present instead of what happened nine years ago.  
+
+Maybe that’s the real shift: from guarding the past to engaging with the present. From being the keeper of lore to being a student again. And honestly, that feels like a good trade.  


### PR DESCRIPTION
Introduce a blog post that reflects on the journey from holding extensive institutional knowledge to embracing a mindset of curiosity and learning in a new role. The piece explores the challenges and growth that come with this transition.