### PR TITLE
Center align GitHub Sponsors call-to-action in post layout and external content

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ layout: default
     <div class="sponsors-cta" style="margin-top: 40px; padding: 20px; border: 1px solid #30363d; border-radius: 8px; background: #0d1117;">
         <h3 style="margin-top: 0; color: #e6edf3;">💖 Support My Work</h3>
         <p style="color: #c9d1d9;">If you enjoyed this post and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank" style="color: #58a6ff;">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
-        <p style="margin-bottom: 0;">
+        <p style="margin-bottom: 0; text-align: center;">
             <a href="https://github.com/sponsors/kitzy" target="_blank">
                 <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" style="max-width: 100%; height: auto;" />
             </a>

--- a/assets/js/external-content.js
+++ b/assets/js/external-content.js
@@ -50,7 +50,7 @@ async function loadExternalAboutContent() {
             <hr>
             <h3>💖 Support My Work</h3>
             <p>If you enjoy my content and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
-            <p>
+            <p style="text-align: center;">
                 <a href="https://github.com/sponsors/kitzy" target="_blank">
                     <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" />
                 </a>
@@ -101,7 +101,7 @@ async function loadExternalAboutContent() {
             
             <p>If you enjoy my content and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
             
-            <p>
+            <p style="text-align: center;">
                 <a href="https://github.com/sponsors/kitzy" target="_blank">
                     <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" />
                 </a>


### PR DESCRIPTION
Update the alignment of the GitHub Sponsors call-to-action to center in both the post layout and external content sections for improved visibility and aesthetics.