### PR TITLE
Refactor content licensing details in documentation and add LICENSE file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
-# Copilot Instructions for kitzy.github.io
+# Copilot Instructions
 
-This is Kitzy's personal Jekyll site hosted on GitHub Pages with custom GitHub Actions deployment. The site showcases professional profile, ### File Management
+This is a personal Jekyll site hosted on GitHub Pages with custom GitHub Actions deployment. The site showcases professional profile, ### File Management
 
 ### Important Patterns
 - **Generated**: `_site/` directory is Jekyll output, git-ignored
@@ -110,11 +110,11 @@ permalink: /custom-url/  # Optional
 ---
 ```
 
-### Personal Context (from README.md)
-- **Identity**: AuDHD (autism + ADHD), Customer Support Engineer at Fleet
-- **Communication**: Direct, clear, authentic preferred
+### Content Guidelines
+- **Code License**: MIT License (open source)
+- **Content License**: All rights reserved (publicly viewable but not open source)
+- **Communication Style**: Direct, clear, authentic
 - **Values**: Empathy, curiosity, authenticity, growth, playfulness
-- **Work Style**: Collaborative, variety-loving, needs clear priorities
 
 ## Component Patterns
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,32 @@
+Copyright (c) 2025 Kitzy
+
+Portions of this software are licensed as follows:
+
+* All content residing under the "content/" directory of this repository is 
+  Copyright (c) 2025 Kitzy and all rights reserved. This includes blog posts,
+  pages, and personal information. While publicly viewable, this content is
+  not licensed for reuse or redistribution.
+
+* All other content, including but not limited to Jekyll configuration files,
+  Ruby plugins, JavaScript files, HTML layouts, and CSS styles, is available
+  under the "MIT Expat" license as defined below.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Personal Jekyll site hosted on GitHub Pages showcasing professional profile, blo
 
 🌐 **Live Site**: [kitzy.com](https://kitzy.com)  
 
-## Open Source + Personal Content
+## Open Source Code + Public Content
 
 This repository contains:
-- ✅ **Open-source code**: Jekyll configuration, plugins, layouts, and JavaScript
-- ❌ **Private content**: Blog posts, pages, and personal information (in `content/` directory)
+- ✅ **Open-source code**: Jekyll configuration, plugins, layouts, and JavaScript (MIT License)
+- 📝 **Public content**: Blog posts, pages, and personal information (in `content/` directory)
 
-The `content/` directory is excluded from the public repository via `.gitignore`. If you fork this project, you'll need to create your own `content/` directory with your content files.  
+The **code** is open source and free to use. The **content** (blog posts, pages, personal information) is publicly viewable on the website but retains all rights reserved - it is not licensed for reuse. If you fork this project, please create your own original content in the `content/` directory.  
 
 ## Architecture Overview
 
@@ -319,4 +319,8 @@ This is a personal site, but if you notice issues:
 
 ## License
 
-This project is open source. Feel free to use as inspiration for your own Jekyll site.
+**Code**: Open source under the MIT License. Feel free to use, modify, and distribute the code.
+
+**Content**: All content in the `content/` directory (blog posts, pages, personal information) is © Kitzy and all rights reserved. The content is publicly viewable but not licensed for reuse or redistribution.
+
+Feel free to use the code as inspiration for your own Jekyll site, but please create your own original content.

--- a/content/README.md
+++ b/content/README.md
@@ -11,12 +11,12 @@ This directory contains all the personal content for the site. It is intentional
 
 ## Why This Exists
 
-This site's **code** is open source, but the **content** (blog posts, personal information, etc.) is not. By keeping all content in this single directory, it's easy to:
+This site's **code** is open source (MIT License), but the **content** (blog posts, personal information, etc.) is publicly viewable but not open source licensed. By keeping all content in this single directory, it's easy to:
 
-1. Exclude it from public repositories
+1. Make the distinction between code and content explicit
 2. Back it up separately
-3. Make the boundary between code and content explicit
+3. Indicate clearly what is open source vs. publicly viewable
 
-## Not Open-Sourced
+## Licensing Note
 
-This directory is listed in `.gitignore` and should not be committed to the public repository. If you fork this project, you'll need to create your own `content/` directory with your own content files.
+While this content is publicly viewable on the website and in this repository, it is **not open source**. All content in this directory is © Kitzy and all rights reserved. If you fork this project, please create your own original content files.


### PR DESCRIPTION
Clarify the licensing of code and content in the documentation. Introduce a LICENSE file to specify the MIT License for code while reserving all rights for the content.