### PR TITLE
Fix CVE-2025-61594: Update uri gem to 1.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.4.0)
     unicode-display_width (2.6.0)
-    uri (1.0.3)
+    uri (1.0.4)
     webrick (1.9.1)
 
 PLATFORMS


### PR DESCRIPTION
## Security Vulnerability Fix

This PR addresses the security audit failure identified in PR #86.

### Changes
- Updates  gem from version 1.0.3 to 1.0.4
- Fixes CVE-2025-61594: URI Credential Leakage Bypass over CVE-2025-27221

### Verification
✅ Security audit passes with no vulnerabilities found
✅ Bundle update completed successfully

### Related
- Closes security audit failure in #86
- CVE Details: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594