### PR TITLE
Add Mastodon verification meta tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,6 +20,9 @@
 <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 <meta name="twitter:image" content="{{ site.social.image }}">
 
+<!-- Fediverse/Mastodon -->
+<meta name="fediverse:creator" content="@kitzy@hachyderm.io">
+
 <!-- LinkedIn/Professional Networks -->
 <meta property="article:author" content="{{ site.title }}">
 {% if page.layout == 'post' %}


### PR DESCRIPTION
This PR adds Mastodon/Fediverse verification support:

- Adds `<meta name="fediverse:creator" content="@kitzy@hachyderm.io">` to all pages
- This meta tag enables Mastodon verification when combined with the `rel="me"` link in the sidebar

The meta tag is added to `_includes/head.html` so it appears on all pages including blog posts.