### PR TITLE
Add Chef context and update meta description for DDM post

### DIFF
--- a/content/_posts/2025-11-14-ive-been-talking-about-declarative-device-management-since-2017.md
+++ b/content/_posts/2025-11-14-ive-been-talking-about-declarative-device-management-since-2017.md
@@ -26,7 +26,9 @@ The automation was the point. I literally said on stage: "I really hate having t
 
 ## The next logical step I couldn't take
 
-What I was striving towards in 2017 was essentially GitOps for endpoint management. The problem? There was no way to actually implement it with the tools available. Jamf, like every other MDM at the time (and most still today), stored everything in a proprietary database. You could export some things via API, but you couldn't define your entire configuration as code and have the system enforce it.
+The approach in this talk was inspired by some work I had done with Chef for managing our Jamf servers. I immediatly saw the power of being able to define, in code, what I wanted the state of the device to be, and leaving it up to the tooling to figure out the how. What I _really_ wanted was essentially GitOps for endpoint management.
+
+The problem? There was no way to actually implement it with the tools available. Jamf, like every other MDM at the time (and most still today), stored everything in a proprietary database. You could export some things via API, but you couldn't define your entire configuration as code and have the system enforce it.
 
 I was trying to achieve declarative management through imperative tools. Smart groups and ongoing policies were as close as I could get, but I was still clicking through interfaces, still manually creating policies, still hoping someone documented what changed and why.
 


### PR DESCRIPTION
Adds context about how the 2017 Desired State Management talk was inspired by work with Chef for managing Jamf servers. This helps explain the connection between infrastructure-as-code tooling and the desire for GitOps in endpoint management.

Also updates the meta description to better emphasize the historical context from the 2017 talk.