### PR TITLE
Remove GitHub Sponsors elements from website

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,15 +31,4 @@ layout: default
     {% endif %}
     
     {{ content }}
-    
-    <!-- GitHub Sponsors CTA -->
-    <div class="sponsors-cta" style="margin-top: 40px; padding: 20px; border: 1px solid #30363d; border-radius: 8px; background: #0d1117;">
-        <h3 style="margin-top: 0; color: #e6edf3;">💖 Support My Work</h3>
-        <p style="color: #c9d1d9;">If you enjoyed this post and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank" style="color: #58a6ff;">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
-        <p style="margin-bottom: 0; text-align: center;">
-            <a href="https://github.com/sponsors/kitzy" target="_blank">
-                <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" style="max-width: 100%; height: auto;" />
-            </a>
-        </p>
-    </div>
 </div>

--- a/assets/js/external-content.js
+++ b/assets/js/external-content.js
@@ -43,21 +43,6 @@ async function loadExternalAboutContent() {
         // Update the container with fetched content
         aboutContainer.innerHTML = htmlContent;
         
-        // Add GitHub Sponsors CTA after the main content
-        const sponsorCTA = document.createElement('div');
-        sponsorCTA.className = 'sponsor-cta';
-        sponsorCTA.innerHTML = `
-            <hr>
-            <h3>💖 Support My Work</h3>
-            <p>If you enjoy my content and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
-            <p style="text-align: center;">
-                <a href="https://github.com/sponsors/kitzy" target="_blank">
-                    <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" />
-                </a>
-            </p>
-        `;
-        aboutContainer.appendChild(sponsorCTA);
-        
         // Fix specific link - the README link should point to the /readme/ page
         const readmeLinks = aboutContainer.querySelectorAll('a[href*="README"]');
         readmeLinks.forEach(link => {
@@ -95,17 +80,6 @@ async function loadExternalAboutContent() {
                 <li>📖 Curious how I work best? Check out my <a href="/readme/">personal user manual</a></li>
             </ul>
             
-            <hr>
-            
-            <h3>💖 Support My Work</h3>
-            
-            <p>If you enjoy my content and want to support my blogging and open-source work, consider becoming a sponsor on <a href="https://github.com/sponsors/kitzy" target="_blank">GitHub Sponsors</a>. Your support helps me continue creating and sharing valuable resources!</p>
-            
-            <p style="text-align: center;">
-                <a href="https://github.com/sponsors/kitzy" target="_blank">
-                    <img src="https://img.shields.io/github/sponsors/kitzy?style=for-the-badge&logo=github&logoColor=white&labelColor=gray&color=pink" alt="GitHub Sponsors" />
-                </a>
-            </p>
         `;
     }
 }

--- a/assets/js/github-integration.js
+++ b/assets/js/github-integration.js
@@ -120,12 +120,9 @@ async function loadBioFromAPI(username) {
     // Update bio if available
     const bioContainer = document.getElementById('github-bio');
     if (bioContainer && user.bio) {
-        // Remove @fleetdm from bio and add sponsors badge
+        // Remove @fleetdm from bio
         let cleanBio = user.bio.replace(/@fleetdm/g, '').replace(/\s+/g, ' ').trim();
         bioContainer.textContent = cleanBio;
-        
-        // Add sponsors badge after bio
-        addSponsorsBadge(bioContainer);
         
         console.log('Updated bio:', cleanBio);
     }
@@ -144,29 +141,6 @@ function removeFleetCompanyDetails() {
             item.style.display = 'none';
         }
     });
-}
-
-function addSponsorsBadge(bioContainer) {
-    // Remove any existing sponsors badge
-    const existingBadge = document.querySelector('.sponsors-badge-container');
-    if (existingBadge) {
-        existingBadge.remove();
-    }
-    
-    // Create sponsors badge container
-    const sponsorsBadge = document.createElement('div');
-    sponsorsBadge.className = 'sponsors-badge-container';
-    sponsorsBadge.style.marginTop = '10px';
-    sponsorsBadge.innerHTML = `
-        <a href="https://github.com/sponsors/kitzy" target="_blank">
-            <img src="https://img.shields.io/github/sponsors/kitzy?style=flat&logo=github&logoColor=white&labelColor=gray&color=pink" 
-                 alt="GitHub Sponsors" 
-                 style="max-width: 100%; height: auto;" />
-        </a>
-    `;
-    
-    // Insert after the bio container
-    bioContainer.parentNode.insertBefore(sponsorsBadge, bioContainer.nextSibling);
 }
 
 function updateLanguagesDisplay(languages) {
@@ -223,13 +197,10 @@ function setFallbackBio() {
         // Set fallback bio without @fleetdm mention
         bioContainer.textContent = 'Customer Support Engineer | Infrastructure Nerd | Dog & Motorcycle Lover';
         
-        // Add sponsors badge
-        addSponsorsBadge(bioContainer);
-        
         // Remove Fleet company details
         removeFleetCompanyDetails();
         
-        console.log('✅ Fallback bio and sponsors badge set successfully');
+        console.log('✅ Fallback bio set successfully');
     }
 }
 


### PR DESCRIPTION
Removes all GitHub Sponsors CTAs and badges from the site:

- **Sidebar**: Removed sponsors badge that appeared after the bio
- **Homepage**: Removed sponsor CTA section from about page content (both live API-fetched and fallback content)
- **Blog posts**: Removed sponsors CTA that appeared at the bottom of each post

This includes cleaning up the `addSponsorsBadge()` function and all calls to it in the JavaScript files.

**Files changed:**
- `_layouts/post.html` - Removed sponsors CTA section
- `assets/js/github-integration.js` - Removed sponsors badge logic
- `assets/js/external-content.js` - Removed sponsor CTA from homepage

**Testing:**
Verified locally with `bundle exec jekyll serve` - all sponsorship elements successfully removed from sidebar, homepage, and blog posts.