### PR TITLE
Remove email from sidebar

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,8 +121,9 @@ permalink: /custom-url/  # Optional
 ### Sidebar Dynamic Content (`_includes/sidebar.html`)
 - **Languages**: Populated by JavaScript from build-time or API data
 - **Organizations**: Always fetched from public GitHub API
-- **Bio**: API-fetched, removes @fleetdm mentions, adds sponsors badge
+- **Bio**: API-fetched, removes @fleetdm mentions
 - **Social Links**: Hardcoded GitHub, LinkedIn, Bluesky, Slack
+- **Email**: Removed from display (not shown in sidebar)
 
 ### Navigation System (`_layouts/default.html`)
 - **Active State**: Compares `page.url` with navigation URLs

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,13 +26,6 @@
             </div>
             {% endif %}
             
-            {% if site.github.owner.email %}
-            <div class="detail-item">
-                <span class="detail-icon">✉️</span>
-                <span class="detail-text">{{ site.github.owner.email }}</span>
-            </div>
-            {% endif %}
-            
             <div class="social-links">
                 <div class="detail-item">
                     <svg class="detail-icon social-icon" viewBox="0 0 24 24" fill="currentColor">


### PR DESCRIPTION
**Issue**: Email address is being displayed in the sidebar, which wasn't intended.

**Changes:**
- Remove email display section from `_includes/sidebar.html`
- Update copilot instructions to reflect that sponsors badge has been removed

The email field still exists in the GitHub metadata, but it won't be displayed on the site anymore.