### PR TITLE
Fix tag icon alignment on blog page

### DIFF
--- a/content/pages/blog.md
+++ b/content/pages/blog.md
@@ -32,11 +32,12 @@ permalink: /blog/
                     
                     {% if post.tags and post.tags.size > 0 %}
                         <p class="post-meta">
-                            <span class="tag-icon">🏷️</span>
-                            <span class="post-tags">
-                                {% for tag in post.tags %}
-                                    <a href="/tag/{{ tag | slugify }}/" class="post-tag">{{ tag }}</a>
-                                {% endfor %}
+                            <span style="display: inline-flex; align-items: flex-start;">
+                                <span class="tag-icon">🏷️</span><span class="post-tags">
+                                    {% for tag in post.tags %}
+                                        <a href="/tag/{{ tag | slugify }}/" class="post-tag">{{ tag }}</a>
+                                    {% endfor %}
+                                </span>
                             </span>
                         </p>
                     {% endif %}


### PR DESCRIPTION
Fixes the tag icon breaking onto a separate line from the tags on the blog page.

**Changes:**
- Wrapped tag icon and tags in a single flex container to prevent them from wrapping separately
- Changed alignment to `flex-start` so the tag icon aligns with the top/first line of tags when they wrap to multiple lines

**Before:** Tag icon would sometimes appear on its own line or be vertically centered between wrapped tag rows

**After:** Tag icon stays on the same line as the tags and aligns with the first line when tags wrap