### PR TITLE
Add timezone configuration to prevent premature publishing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ description: "Always automating, always iterating, always helping others."
 baseurl: ""
 url: "https://kitzy.com"
 author: "Kitzy"
+timezone: America/New_York
 
 # GitHub settings
 github_username: kitzy


### PR DESCRIPTION
Adds timezone: America/New_York to _config.yml so Jekyll interprets post dates in EST/EDT instead of UTC.

This will fix the issue where posts dated for tomorrow were being published early because midnight UTC arrived before midnight EST.

The OpenClaw post will be un-published on the next build and will automatically re-publish at midnight EST on Feb 6.