### PR TITLE
Fix workflow concurrency to allow PR builds to run without queuing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# Concurrency strategy: PRs run concurrently (each in their own group), main branch deploys sequentially
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:


### PR DESCRIPTION
## Problem
PR builds for the Jekyll deployment workflow were getting stuck in 'queued' status indefinitely because the concurrency configuration used a global 'pages' group that blocked all workflows, even though PR builds don't deploy.

## Solution
Updated the concurrency configuration to:
- Use per-PR concurrency groups: Each PR gets its own group instead of all workflows sharing the 'pages' group
- Allow PR builds to cancel previous runs when new commits are pushed
- Keep main branch deployments sequential for safety

## Impact
- PR builds will now start immediately instead of queuing
- Multiple PRs can have their workflows running concurrently
- Main branch deployments remain safe with sequential execution
- Fixes the issue where PR #185 was stuck in queue

#185