### PR TITLE
Remove unused PERSONAL_GITHUB_TOKEN references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,21 +38,13 @@ bundle exec jekyll serve --port 4000
 
 ### Deployment Process
 - **Trigger**: Push to main branch, PR creation, manual dispatch, weekly cron
-- **Build**: Custom GitHub Actions workflow with Ruby 3.1 + Jekyll + plugins
-- **Token**: Uses `PERSONAL_GITHUB_TOKEN` secret for private repo access during build
+- **Build**: Custom GitHub Actions workflow with Ruby 3.2 + Jekyll + plugins
 - **Deploy**: Automatic to GitHub Pages after successful build
 
 ## Project-Specific Patterns
 
-### Dual GitHub Integration System
-1. **Build-time**: `_plugins/github_languages.rb` calculates language stats from ALL repos (public + private) using token
-2. **Runtime**: `assets/js/github-integration.js` fetches public API data for organizations, bio, fallbacks
-3. **Data Flow**: Build-time data injected via `window.githubLanguagesData` in `_layouts/default.html`
-
-### Custom Language Calculation
-- **Weight Formula**: `(stars + forks + 1)` per repo with that language
-- **Processing**: All repos (including forks) counted, top 8 languages returned
-- **Fallback**: Static language array when token unavailable
+### GitHub Integration
+- **Runtime**: `assets/js/github-integration.js` fetches public API data for organizations, bio, fallbacks
 
 ### Content Organization
 - **Posts**: `content/_posts/YYYY-MM-DD-title.md` format with post layout (underscore required)
@@ -84,8 +76,7 @@ collections:
 ```
 
 ### Required Environment Variables
-- `PERSONAL_GITHUB_TOKEN`: GitHub token for private repo access during build
-- Must be set in GitHub repository secrets for Actions workflow
+- None. The build has no external token dependencies.
 
 ## Content Guidelines
 
@@ -137,11 +128,8 @@ permalink: /custom-url/  # Optional
 
 ## Build System Details
 
-### Custom Plugin: `_plugins/github_languages.rb`
-- **Purpose**: Generate language statistics from authenticated GitHub API
-- **Token Check**: Falls back to static data if `PERSONAL_GITHUB_TOKEN` unavailable
-- **Rate Limiting**: 0.1s sleep between API calls
-- **Output**: `site.data['github_languages']` with languages array + metadata
+### Custom Plugin: `_plugins/tag_generator.rb`
+- **Purpose**: Generate tag index pages and RSS feeds for each post tag
 
 ### Jekyll Processing
 - **Markdown**: kramdown processor
@@ -162,9 +150,8 @@ permalink: /custom-url/  # Optional
 3. Follow branch workflow: feature branch → PR → merge
 
 ### Updating GitHub Integration
-1. **Build-time**: Modify `_plugins/github_languages.rb` for data processing
-2. **Runtime**: Edit `assets/js/github-integration.js` for API calls/display
-3. Test fallback behavior (no token scenario)
+1. Edit `assets/js/github-integration.js` for API calls/display
+2. Test fallback behavior when API is unavailable
 
 ### Modifying Site Structure
 1. **Navigation**: Update `_config.yml` navigation array
@@ -178,7 +165,6 @@ permalink: /custom-url/  # Optional
 - **Solution**: Always use feature branch + PR workflow, never push to main
 
 ### Build Failures
-- **Token Issues**: Check `PERSONAL_GITHUB_TOKEN` secret exists and has repo access
 - **Jekyll Errors**: Validate YAML frontmatter syntax in posts/pages
 - **Plugin Errors**: Check Ruby syntax in `_plugins/` directory
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,6 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-          PERSONAL_GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -39,16 +39,6 @@ bundle exec jekyll serve --port 4000
 
 Visit: [http://localhost:4000](http://localhost:4000)
 
-### Required Environment Variables
-
-For full functionality, set in your build environment:
-
-```bash
-export PERSONAL_GITHUB_TOKEN="your_github_token"
-```
-
-This enables private repository access for language statistics during build.
-
 ## Development Workflow
 
 **⚠️ Important**: Main branch is protected. All changes must go through pull requests.
@@ -84,7 +74,7 @@ kitzy.github.io/
 │   ├── post.html           # Blog post layout
 │   └── redirect.html       # Redirect template
 ├── _plugins/               # Custom Jekyll plugins
-│   └── github_languages.rb # Language stats generator
+│   └── tag_generator.rb    # Tag page generator
 ├── assets/js/              # JavaScript modules
 │   ├── main.js            # Core functionality
 │   ├── github-integration.js
@@ -107,17 +97,11 @@ kitzy.github.io/
 
 ## Key Features
 
-### Dual GitHub Integration System
+### GitHub Integration
 
-1. **Build-time Language Stats** (`_plugins/github_languages.rb`)
-   - Calculates weighted language statistics from all repositories
-   - Requires `PERSONAL_GITHUB_TOKEN` for private repo access
-   - Weight formula: `(stars + forks + 1)` per language per repo
-   - Outputs top 8 languages to `site.data['github_languages']`
-
-2. **Runtime Public Data** (`assets/js/github-integration.js`)
+**Runtime Public Data** (`assets/js/github-integration.js`)
    - Fetches organizations, bio, and public repository data
-   - Provides fallbacks when build-time data unavailable
+   - Provides fallbacks when API is unavailable
    - Handles API rate limiting gracefully
 
 ## Content Management
@@ -184,9 +168,8 @@ Deployment triggers on:
 The `.github/workflows/deploy.yml` workflow:
 
 1. **Build**: Ruby 3.2 + Jekyll + custom plugins
-2. **Authentication**: Uses `PERSONAL_GITHUB_TOKEN` secret
-3. **Deploy**: Automatic to GitHub Pages after successful build
-4. **Permissions**: Pages write access via GITHUB_TOKEN
+2. **Deploy**: Automatic to GitHub Pages after successful build
+3. **Permissions**: Pages write access via GITHUB_TOKEN
 
 ### Manual Deploy
 
@@ -238,14 +221,6 @@ navigation:
 3. **Components**: Create includes in `_includes/`
 4. **Plugins**: Add Ruby plugins to `_plugins/`
 
-### Language Statistics
-
-Modify `_plugins/github_languages.rb` to change:
-- Weighting algorithm
-- Number of languages displayed
-- Excluded repositories
-- Fallback behavior
-
 ### Sidebar Content
 
 Edit `_includes/sidebar.html` to modify:
@@ -259,7 +234,6 @@ Edit `_includes/sidebar.html` to modify:
 ### Common Issues
 
 **Build Failures**
-- Check `PERSONAL_GITHUB_TOKEN` secret exists
 - Validate YAML frontmatter in posts/pages
 - Review Actions workflow logs
 
@@ -294,12 +268,6 @@ bundle exec jekyll serve --port 4001
 - `bundle-audit` for vulnerability scanning
 - Regular dependency updates via Dependabot
 - Security audit workflow in `.github/workflows/`
-
-### Token Permissions
-
-The `PERSONAL_GITHUB_TOKEN` should have minimal required scopes:
-- `repo` (for private repository access)
-- `read:org` (for organization data)
 
 ## Performance
 

--- a/_config.yml
+++ b/_config.yml
@@ -10,9 +10,6 @@ timezone: America/New_York
 github_username: kitzy
 repository: kitzy/kitzy.com
 
-# GitHub token for build-time language calculation (set in environment)
-# Set PERSONAL_GITHUB_TOKEN in your build environment for private repo access
-
 # Build settings
 markdown: kramdown
 highlighter: rouge


### PR DESCRIPTION
The `github_languages.rb` plugin was previously removed, making the `PERSONAL_GITHUB_TOKEN` secret unnecessary. This PR cleans up all remaining references.

### Changes
- `.github/workflows/deploy.yml`: Remove token env var from Jekyll build step
- `README.md`: Remove token setup instructions, stale plugin docs, token troubleshooting, and token permissions section
- `.github/copilot-instructions.md`: Update to reflect single runtime GitHub integration, correct plugin reference to `tag_generator.rb`, remove token from required env vars
- `_config.yml`: Remove stale comment about token

### Follow-up
Delete the `PERSONAL_GITHUB_TOKEN` secret from GitHub repo Settings → Secrets and variables → Actions.