### PR TITLE
Add blog post: Does Idaho's bathroom ban protect women?

### DIFF
--- a/content/_posts/2026/03/2026-03-28-does-idahos-bathroom-ban-protect-women.md
+++ b/content/_posts/2026/03/2026-03-28-does-idahos-bathroom-ban-protect-women.md
@@ -1,0 +1,103 @@
+---
+layout: post
+title: "Does Idaho's bathroom ban protect women?"
+description: "Idaho's HB 752 creates felony penalties for using the wrong bathroom - harsher than drunk driving. Let's ask honestly whether it accomplishes what it claims."
+date: 2026-03-28
+tags: [politics, community, belonging]
+---
+
+Let me start with something I don't want to gloss over: the concern behind this kind of legislation is real.
+
+Women have good reasons to think about safety in spaces where they're vulnerable. Sexual violence happens. Perpetrators sometimes exploit access to commit it. Wanting to protect women from that isn't bigotry - it's a reasonable instinct.
+
+So let's take Idaho's [House Bill 752](https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0752.pdf) completely at face value. The stated goal is to prevent men from accessing women's spaces and causing harm. Let's ask honestly: does this law accomplish that? Does it create problems it doesn't account for? And is the punishment even remotely proportional to the threat?
+
+I think the answer to all three questions leads somewhere lawmakers probably don't want to go.
+
+## The punishment doesn't fit any rational threat assessment
+
+Before we even get to the logic of the law, let's look at what it actually does.
+
+Under HB 752, a first offense - entering a bathroom that doesn't match your birth sex - carries up to one year in jail. A second offense within five years is a felony, punishable by up to five years in prison. A third offense, under Idaho's persistent violator statute, carries five years to life.
+
+Now compare that to drunk driving - a crime that killed [110 people and seriously injured 291 more in Idaho in 2022](https://apps.itd.idaho.gov/Apps/OHS/Crash/22/Impaired.pdf), representing over half of all traffic fatalities in the state that year.
+
+Under Idaho's [DUI statute](https://legislature.idaho.gov/statutesrules/idstat/title18/t18ch80/sect18-8005/), a first offense carries a maximum of six months in jail. No mandatory minimum. A second offense remains a misdemeanor, with a mandatory minimum of ten days. Drunk driving doesn't become a felony until the *third* conviction.
+
+In Idaho, using the wrong bathroom on your first offense carries twice the maximum sentence of driving drunk and killing someone.
+
+Ask yourself: what does that say about what this law is actually for? Is someone needing to pee really a greater threat to public safety than someone getting behind the wheel drunk? Because Idaho's criminal code suggests it is - and 110 families who lost someone to an impaired driver in 2022 might have something to say about that.
+
+## The law's own logic doesn't hold
+
+Here's the serious version of the argument for bathroom bans: we need to prevent bad actors - specifically cisgender men - from claiming to be transgender women in order to gain access to women's spaces.
+
+That's worth taking seriously. So let's.
+
+Under HB 752, transgender men - people who were assigned female at birth and have transitioned to living as men - are now legally *required* to use women's bathrooms.
+
+Think about what that means for the threat this law claims to address.
+
+A cisgender man who wants to gain access to women's spaces no longer needs to claim to be a transgender woman. He can claim to be a transgender man. Under this law, he is now legally entitled to be there. The very vector of access this law is trying to close just got wider.
+
+How does that work, exactly? If the concern is bad-faith actors exploiting gender-identity claims, how does legally requiring anyone assigned female at birth to use women's bathrooms - regardless of how they present, dress, or identify - close that loophole? What's the theory of the case here?
+
+There isn't a good answer that doesn't undermine the entire premise.
+
+## Who verifies any of this, and how?
+
+The law doesn't explain how enforcement works. When you start asking that question, things get considerably worse.
+
+What happens when someone suspects the person in the women's bathroom isn't a cisgender woman? Does she have to produce documentation? What documentation? Who decides if it's sufficient?
+
+[Idaho's own Fraternal Order of Police](https://idahocapitalsun.com/2026/03/27/idaho-legislature-passes-bill-to-criminalize-trans-people-using-preferred-bathrooms/) President Bryan Lovell wrote that there is "no clear or reasonable way" for officers to determine someone's biological sex "without engaging in questioning or investigative actions that could be viewed as invasive and inappropriate." The Sheriffs' Association and the Chiefs of Police Association both opposed this bill too. Idaho's law enforcement - the people who would actually enforce this - don't want it.
+
+And the edge cases here are not abstract. What about a transgender woman who has had gender-affirming surgery? Her anatomy matches the bathroom she's been using. How is her "biological sex" determined, and by whom? What about an intersex person, whose biology doesn't fit the binary this law assumes? What about a cisgender woman who is androgynous, or presents in ways some people find ambiguous?
+
+What recourse does she have when someone questions whether she belongs there?
+
+What exactly are we asking police to do here - and to whom?
+
+This law, as written, exposes cisgender women to interrogation, detention, and humiliation for being in a bathroom while looking like someone's idea of "not feminine enough." That's not an unforeseen side effect. It's an inevitable consequence of a law with no workable enforcement mechanism.
+
+## Where this law actually sends transgender women
+
+Here's the part that gets least attention in these debates.
+
+HB 752 doesn't remove transgender women from women's bathrooms and leave things otherwise neutral. It sends them somewhere. Specifically, it sends them into men's bathrooms.
+
+Is that safer? For whom?
+
+A [2025 study published in *Violence Against Women*](https://pmc.ncbi.nlm.nih.gov/articles/PMC12446682/) examining fatal violence against Black transgender women found that among cases where perpetrators were identified, 75% were cisgender men. Transgender women are already [four times more likely to experience violent victimization](https://williamsinstitute.law.ucla.edu/press/ncvs-trans-press-release/) than cisgender people overall.
+
+This law takes one of the most at-risk populations in the country and legally forces them into the spaces where they face the greatest danger. That's not a trade-off. That's just harm redistribution - and the harm lands on people who were already vulnerable.
+
+The [2015 U.S. Transgender Survey](https://www.nbcnews.com/feature/nbc-out/u-s-transgender-people-harassed-public-restrooms-landmark-survey-n693596) found that 59% of transgender people already avoid public restrooms out of fear. A [2022 study published in *Pediatrics*](https://pmc.ncbi.nlm.nih.gov/articles/PMC8849575/) found that transgender youth with *restricted* bathroom access faced a 36% sexual assault prevalence, compared to 24% for those with unrestricted access. Bathroom restrictions don't protect people. They expose people to harm.
+
+Who exactly is safer after this law passes?
+
+## What does the evidence actually show?
+
+At this point you might be wondering: has any of this ever happened? Is there documented evidence of transgender-inclusive bathroom policies leading to increased sexual violence?
+
+The answer, across multiple independent studies, is no.
+
+A [2019 peer-reviewed study in *Sexuality Research and Social Policy*](https://link.springer.com/article/10.1007/s13178-018-0335-z) compared criminal incident rates across Massachusetts localities with and without gender identity nondiscrimination ordinances. The researchers found no relationship - not a small one, not a statistically insignificant one. None. A [Police Foundation review](https://www.policinginstitute.org/wp-content/uploads/2017/07/PF_Research-Brief_JULY-2017-FINAL-1.pdf) examined 2,549 sexual assault complaints across four cities before and after each adopted gender identity protections. Zero cases of anyone exploiting those protections to commit an assault. [Williams Institute research](https://williamsinstitute.law.ucla.edu/publications/ma-public-accommodations/) using national crime data found no increase in victimization rates following adoption of nondiscrimination laws.
+
+[Over 300 sexual assault and domestic violence organizations](https://abcnews.go.com/US/sexual-assault-domestic-violence-organizations-debunk-bathroom-predator/story?id=38604019) - including the National Sexual Violence Resource Center - have called claims about bathroom predators false. These aren't advocacy organizations. These are the people who work with survivors of sexual violence every day. They've looked at the evidence and reached the same conclusion the researchers did.
+
+Cases that get cited as proof of the threat rarely hold up. The [Loudoun County, Virginia assault in 2021](https://reason.com/2021/11/01/conservatives-wrongly-portrayed-the-loudoun-county-sexual-assault-as-a-transgender-bathroom-issue/) - probably the most politically weaponized bathroom case in recent years - involved a perpetrator whose own mother confirmed was not transgender, a school policy that didn't yet exist at the time of the assault, and two students who had a prior relationship and arranged to meet. Multiple investigations confirmed it had nothing to do with transgender bathroom access. That didn't stop it from becoming Exhibit A for legislation like this.
+
+It's also worth knowing where the broader argument came from. [Mass Resistance](https://www.intomore.com/impact/anti-lgbtq-activist-admits-bathroom-predator-myth-was-concocted-as-cover-for-transphobic-hate/), an anti-LGBTQ organization, publicly acknowledged in 2018 that "our side concocted the 'bathroom safety' male predator argument" as a strategic framing choice. The threat this law is designed to prevent doesn't appear in the data because, according to the people who invented the argument, it was invented to serve a different purpose.
+
+## So who does this actually protect?
+
+I'll be honest: I don't have a neat answer to that.
+
+Some of the people who voted for this law probably genuinely believe they're protecting women. I want to take that at face value where I can.
+
+But when I look at what HB 752 actually does - the felony penalties that exceed those for drunk driving, the logical hole that makes the stated problem worse, the enforcement mechanics that inevitably sweep up cisgender women, the total absence of evidence for the threat it's responding to, and the documented harm it will cause to transgender people forced into dangerous spaces - I have a hard time concluding it was designed around outcomes.
+
+If protecting women was the real goal, we'd start with the things that actually harm women. We'd ask who the documented perpetrators are. We'd look at the research and follow where it leads. We'd talk about the hundred Idahoans killed by drunk drivers every year and ask why those comparatively mild consequences are apparently fine.
+
+What we wouldn't do is create a felony for needing to use a bathroom - and call it protecting women.


### PR DESCRIPTION
Adds a new blog post analyzing Idaho's HB 752 bathroom ban legislation, examining whether the law accomplishes its stated goals of protecting women and whether the penalties are proportional to the threat.