### PR TITLE
Revamp projects page with featured repos and nav link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,6 +82,8 @@ social:
 navigation:
   - title: "Blog"
     url: "/"
+  - title: "Projects"
+    url: "/projects/"
   - title: "Podcasts"
     url: "/podcasts/"
   - title: "README"

--- a/content/pages/projects.md
+++ b/content/pages/projects.md
@@ -1,70 +1,47 @@
 ---
 layout: default
 title: Projects
-description: "My projects and contributions"
+description: "My projects and open source contributions"
 permalink: /projects/
 ---
 
-Here are some of my featured projects and contributions.
+Here are some projects I've created and contributed to. I focus mostly on Mac admin tooling - automating the boring parts of device management so you can focus on the things that actually matter.
 
-<div class="projects-grid">
-    <div class="pinned-repo">
+<div class="featured-projects">
+    <div class="featured-project">
         <div class="pinned-repo-header">
             <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path></svg>
-            <a href="https://github.com/kitzy/fleet-gitops" target="_blank" rel="noopener" class="repo-name">fleet-gitops</a>
+            <a href="https://github.com/autopkg/fleet-recipes" target="_blank" rel="noopener" class="repo-name">autopkg/fleet-recipes</a>
             <span class="repo-visibility">Public</span>
         </div>
-        <p class="repo-description">GitOps workflows for managing Fleet MDM configuration as code</p>
-        <div class="repo-footer"><span class="repo-language"><span class="language-color" data-language="yaml"></span>YAML</span></div>
+        <p class="repo-description">A community-maintained AutoPkg repo for uploading macOS packages directly to Fleet or via GitOps workflows. Supports direct API mode, S3-backed GitOps mode, automatic icon extraction from app bundles, and policy automation for keeping software up to date. I created this and serve as the primary maintainer.</p>
+        <div class="repo-footer">
+            <span class="repo-language"><span class="language-color" data-language="python"></span>Python</span>
+            <span class="repo-stat">
+                <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"></path></svg>
+                14
+            </span>
+            <span class="repo-stat">
+                <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"></path></svg>
+                3
+            </span>
+        </div>
     </div>
 
-    <div class="pinned-repo">
+    <div class="featured-project">
         <div class="pinned-repo-header">
             <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path></svg>
-            <a href="https://github.com/kitzy/docker-fleetdm-stack" target="_blank" rel="noopener" class="repo-name">docker-fleetdm-stack</a>
+            <a href="https://github.com/macadmins/icongrabber" target="_blank" rel="noopener" class="repo-name">macadmins/icongrabber</a>
             <span class="repo-visibility">Public</span>
         </div>
-        <p class="repo-description">Docker Compose stack for running a self-hosted Fleet instance locally</p>
-        <div class="repo-footer"><span class="repo-language"><span class="language-color" data-language="dockerfile"></span>Dockerfile</span></div>
-    </div>
-
-    <div class="pinned-repo">
-        <div class="pinned-repo-header">
-            <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path></svg>
-            <a href="https://github.com/kitzy/fleet-autopkg-recipes" target="_blank" rel="noopener" class="repo-name">fleet-autopkg-recipes</a>
-            <span class="repo-visibility">Public</span>
+        <p class="repo-description">A fast, native command-line tool written in Swift to extract high-quality icons from macOS applications. Supports flexible sizing, automatic file size optimization, and is built for automation and batch processing. Created and donated to the Mac Admins Open Source organization.</p>
+        <div class="repo-footer">
+            <span class="repo-language"><span class="language-color" data-language="swift"></span>Swift</span>
+            <span class="repo-stat">
+                <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"></path></svg>
+                35
+            </span>
         </div>
-        <p class="repo-description">AutoPkg processor and recipes for importing software into Fleet</p>
-        <div class="repo-footer"><span class="repo-language"><span class="language-color" data-language="python"></span>Python</span></div>
-    </div>
-
-    <div class="pinned-repo">
-        <div class="pinned-repo-header">
-            <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path></svg>
-            <a href="https://github.com/autopkg/kitzy-recipes" target="_blank" rel="noopener" class="repo-name">kitzy-recipes</a>
-            <span class="repo-visibility">Public</span>
-        </div>
-        <p class="repo-description">AutoPkg recipes contributed to the AutoPkg community repo</p>
-        <div class="repo-footer"><span class="repo-language"><span class="language-color" data-language="python"></span>Python</span></div>
-    </div>
-
-    <div class="pinned-repo">
-        <div class="pinned-repo-header">
-            <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path></svg>
-            <a href="https://github.com/kitzy/dns" target="_blank" rel="noopener" class="repo-name">dns</a>
-            <span class="repo-visibility">Public</span>
-        </div>
-        <p class="repo-description">DNS zone file management</p>
-        <div class="repo-footer"><span class="repo-language"><span class="language-color" data-language="shell"></span>Shell</span></div>
-    </div>
-
-    <div class="pinned-repo">
-        <div class="pinned-repo-header">
-            <svg class="repo-icon" viewBox="0 0 16 16" width="16" height="16"><path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path></svg>
-            <a href="https://github.com/fleetdm/fleet" target="_blank" rel="noopener" class="repo-name">fleetdm/fleet</a>
-            <span class="repo-visibility">Public</span>
-        </div>
-        <p class="repo-description">Open source device management — contributor</p>
-        <div class="repo-footer"><span class="repo-language"><span class="language-color" data-language="go"></span>Go</span></div>
     </div>
 </div>
+

--- a/styles.css
+++ b/styles.css
@@ -1181,6 +1181,33 @@ body {
 .language-color[data-language="javascript"] { background-color: #f1e05a; }
 .language-color[data-language="typescript"] { background-color: #2b7489; }
 .language-color[data-language="dockerfile"] { background-color: #384d54; }
+.language-color[data-language="swift"] { background-color: #F05138; }
+
+/* Featured projects */
+.featured-projects {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+    margin-bottom: 32px;
+}
+
+.featured-project {
+    border: 1px solid #388bfd;
+    border-radius: 6px;
+    padding: 20px;
+    background-color: #0d1117;
+    transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
+}
+
+.featured-project:hover {
+    border-color: #79c0ff;
+    background-color: #161b22;
+}
+
+.featured-project .repo-description {
+    font-size: 13px;
+}
 
 /* Projects grid */
 .projects-grid {


### PR DESCRIPTION
- Adds featured cards for `autopkg/fleet-recipes` and `macadmins/icongrabber` with descriptions, star/fork counts, and language badges
- Removes all other projects from the page
- Adds Projects to site navigation (between Blog and Podcasts)
- Adds `featured-project` CSS styles and Swift language color