### PR TITLE
Revamp talks page with upcoming section and archived toggle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,8 @@ navigation:
     url: "/"
   - title: "Projects"
     url: "/projects/"
+  - title: "Talks"
+    url: "/talks/"
   - title: "Podcasts"
     url: "/podcasts/"
   - title: "README"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,5 +41,6 @@
 
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/blog-pagination.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/talks-toggle.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/js/talks-toggle.js
+++ b/assets/js/talks-toggle.js
@@ -1,0 +1,12 @@
+// Archived talks toggle
+(function() {
+    var btn = document.getElementById('toggle-archived-talks');
+    var section = document.getElementById('archived-talks-section');
+    if (!btn || !section) return;
+
+    btn.addEventListener('click', function() {
+        var isHidden = section.style.display === 'none';
+        section.style.display = isHidden ? 'block' : 'none';
+        btn.textContent = isHidden ? 'Hide archived talks' : 'Show archived talks';
+    });
+})();

--- a/content/pages/talks.md
+++ b/content/pages/talks.md
@@ -6,7 +6,39 @@ permalink: /talks/
 ---
 
 <div class="markdown-content">
-    <div class="speaking-section archived-talks">
+
+    <div class="speaking-section upcoming-talks">
+        <h2>Upcoming Talks</h2>
+        <div class="speaking-grid">
+            <div class="speaking-item upcoming">
+                <div class="speaking-header">
+                    <div class="upcoming-badge">Upcoming</div>
+                    <h3 class="speaking-title">
+                        <a href="https://pshsummit2026.sched.com/event/2AaQT/stop-clicking-and-start-committing-a-gitops-workflow-for-endpoint-management?iframe=no" target="_blank" rel="noopener noreferrer">
+                            Stop clicking and start committing: a GitOps workflow for endpoint management
+                        </a>
+                    </h3>
+                    <div class="speaking-meta">
+                        <span class="speaking-date">April 15, 2026</span>
+                        <span class="speaking-venue">PowerShell + DevOps Global Summit</span>
+                        <span class="speaking-location">Bellevue, WA</span>
+                    </div>
+                </div>
+                <p class="speaking-description">
+                    Every other discipline in IT figured this out years ago. This talk makes the case for moving your MDM into a Git repository — covering why endpoint management got stuck in ClickOps, what config-as-code buys you that a GUI never can (history, diffs, code review, rollbacks), and how AI coding tools accelerate the workflow without removing human review. Includes a live demo of a working sandbox-to-production pipeline with fleetctl and GitHub Actions.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="archived-talks-toggle-container">
+        <button id="toggle-archived-talks" class="toggle-archived-btn">
+            Show archived talks
+        </button>
+    </div>
+
+    <div id="archived-talks-section" class="speaking-section archived-talks" style="display: none;">
+        <h2>Archived Talks</h2>
         <p class="archive-note">These are talks from earlier in my life that I'm still proud of, though they reflect an earlier version of myself that I no longer identify with.</p>
         
         <div class="speaking-grid">
@@ -211,4 +243,5 @@ permalink: /talks/
             </div>
         </div>
     </div>
+
 </div>

--- a/styles.css
+++ b/styles.css
@@ -1493,6 +1493,67 @@ body {
     font-style: italic;
 }
 
+/* Upcoming talks */
+.upcoming-talks h2 {
+    color: #3fb950;
+}
+
+.speaking-item.upcoming {
+    background: #0d1117;
+    border-color: #238636;
+}
+
+.speaking-item.upcoming:hover {
+    border-color: #3fb950;
+    background: #0d1117;
+}
+
+.upcoming-badge {
+    display: inline-block;
+    background: #1a4428;
+    color: #3fb950;
+    border: 1px solid #238636;
+    border-radius: 12px;
+    padding: 2px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+}
+
+.speaking-location {
+    font-size: 13px;
+    color: #7d8590;
+}
+
+.speaking-location::before {
+    content: "📍 ";
+}
+
+/* Archived talks toggle */
+.archived-talks-toggle-container {
+    margin: 8px 0 24px 0;
+}
+
+.toggle-archived-btn {
+    background: #21262d;
+    color: #7d8590;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.toggle-archived-btn:hover {
+    background: #30363d;
+    color: #e6edf3;
+    border-color: #484f58;
+}
+
 /* Responsive design for speaking */
 @media (max-width: 768px) {
     .speaking-grid {


### PR DESCRIPTION
- Adds **Talks** to site navigation between Projects and Podcasts
- Adds **Upcoming Talks** section at the top with the PowerShell + DevOps Global Summit talk (April 15, 2026, Bellevue WA)
- All archived talks are now hidden by default behind a **"Show archived talks"** toggle button
- Adds `talks-toggle.js` for the toggle behavior
- Adds CSS for upcoming talk card (green accent), upcoming badge, location meta, and toggle button