### PR TITLE
Revamp talks page with upcoming section and archived toggle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,8 @@ navigation:
     url: "/"
   - title: "Projects"
     url: "/projects/"
+  - title: "Talks"
+    url: "/talks/"
   - title: "Podcasts"
     url: "/podcasts/"
   - title: "README"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,5 +41,6 @@
 
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/blog-pagination.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/talks-toggle.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/js/talks-toggle.js
+++ b/assets/js/talks-toggle.js
@@ -1,0 +1,12 @@
+// Archived talks toggle
+(function() {
+    var btn = document.getElementById('toggle-archived-talks');
+    var section = document.getElementById('archived-talks-section');
+    if (!btn || !section) return;
+
+    btn.addEventListener('click', function() {
+        var isHidden = section.style.display === 'none';
+        section.style.display = isHidden ? 'block' : 'none';
+        btn.textContent = isHidden ? 'Hide archived talks' : 'Show archived talks';
+    });
+})();

--- a/content/pages/podcasts.md
+++ b/content/pages/podcasts.md
@@ -8,6 +8,7 @@ permalink: /podcasts/
 <div class="markdown-content">
     <div class="speaking-section">
         <h2>Podcast Appearances</h2>
+        <div class="speaking-grid">
         <div class="speaking-item">
             <div class="speaking-header">
                 <h3 class="speaking-title">
@@ -70,6 +71,7 @@ permalink: /podcasts/
             <p class="speaking-description">
                 A feature episode focused on my approach to Mac administration, community building, and the importance of making technical work enjoyable. I discussed my philosophy on bringing fun and creativity to systems administration and fostering inclusive technical communities.
             </p>
+        </div>
         </div>
     </div>
 </div>

--- a/content/pages/talks.md
+++ b/content/pages/talks.md
@@ -12,7 +12,6 @@ permalink: /talks/
         <div class="speaking-grid">
             <div class="speaking-item upcoming">
                 <div class="speaking-header">
-                    <div class="upcoming-badge">Upcoming</div>
                     <h3 class="speaking-title">
                         <a href="https://pshsummit2026.sched.com/event/2AaQT/stop-clicking-and-start-committing-a-gitops-workflow-for-endpoint-management?iframe=no" target="_blank" rel="noopener noreferrer">
                             Stop clicking and start committing: a GitOps workflow for endpoint management
@@ -25,7 +24,85 @@ permalink: /talks/
                     </div>
                 </div>
                 <p class="speaking-description">
-                    Every other discipline in IT figured this out years ago. This talk makes the case for moving your MDM into a Git repository — covering why endpoint management got stuck in ClickOps, what config-as-code buys you that a GUI never can (history, diffs, code review, rollbacks), and how AI coding tools accelerate the workflow without removing human review. Includes a live demo of a working sandbox-to-production pipeline with fleetctl and GitHub Actions.
+                    Every other discipline in IT figured this out years ago. This talk makes the case for moving your MDM into a Git repository - covering why endpoint management got stuck in ClickOps, what config-as-code buys you that a GUI never can (history, diffs, code review, rollbacks), and how AI coding tools accelerate the workflow without removing human review. Includes a live demo of a working sandbox-to-production pipeline with fleetctl and GitHub Actions.
+                </p>
+            </div>
+
+            <div class="speaking-item upcoming">
+                <div class="speaking-header">
+                    <h3 class="speaking-title">
+                        <a href="https://mdoyvr.com/" target="_blank" rel="noopener noreferrer">
+                            Automate software deployment with AutoPkg and Fleet
+                        </a>
+                    </h3>
+                    <div class="speaking-meta">
+                        <span class="speaking-date">June 25–26, 2026</span>
+                        <span class="speaking-venue">MacDevOps:YVR</span>
+                        <span class="speaking-location">Montreal, QC</span>
+                    </div>
+                </div>
+                <p class="speaking-description">
+                    AutoPkg already handles software packaging and updates for thousands of Mac applications. Fleet manages software deployment across your devices. This talk shows you how to connect them - using FleetImporter, a custom AutoPkg processor that adds software directly to Fleet's package management from your AutoPkg runs. We'll cover both direct API mode for quick deployments and GitOps workflows for version-controlled, declarative management.
+                </p>
+            </div>
+
+            <div class="speaking-item upcoming co-talk">
+                <div class="speaking-header">
+                    <h3 class="speaking-title">
+                        <a href="https://mdoyvr.com/" target="_blank" rel="noopener noreferrer">
+                            Not broken, just different: Working with ADHD, anxiety, and neurodivergence in tech
+                        </a>
+                    </h3>
+                    <div class="speaking-meta">
+                        <span class="speaking-date">June 25–26, 2026</span>
+                        <span class="speaking-venue">MacDevOps:YVR</span>
+                        <span class="speaking-location">Montreal, QC</span>
+                    </div>
+                    <div class="speaking-cospeaker">
+                        Co-presented with <a href="https://www.linkedin.com/in/lppepper/" target="_blank" rel="noopener noreferrer">Andrea Pepper</a>
+                    </div>
+                </div>
+                <p class="speaking-description">
+                    Mac Admin work requires staying calm while systems break and priorities shift. For neurodivergent people, this creates predictable challenges. Two neurodivergent technical professionals share practical techniques they use to stay effective: time containment, energy-aware scheduling, professional communication strategies, and when to ask for accommodations. You'll leave with concrete tools you can use during incidents, meetings, and when your brain is loud.
+                </p>
+            </div>
+
+            <div class="speaking-item upcoming">
+                <div class="speaking-header">
+                    <h3 class="speaking-title">
+                        <a href="https://macadmins.psu.edu/" target="_blank" rel="noopener noreferrer">
+                            From recipe to reality: Automating software deployment with AutoPkg and Fleet
+                        </a>
+                    </h3>
+                    <div class="speaking-meta">
+                        <span class="speaking-date">July 7–10, 2026</span>
+                        <span class="speaking-venue">Penn State MacAdmins</span>
+                        <span class="speaking-location">State College, PA</span>
+                    </div>
+                </div>
+                <p class="speaking-description">
+                    A deeper dive than the MacDevOps:YVR session. Learn how to build end-to-end software deployment workflows using AutoPkg and Fleet's open-source platform - covering practical examples of automating everything from package creation to deployment through GitOps workflows. We'll look at how AutoPkg processors integrate with Fleet's API, how to manage software releases declaratively, and how to build repeatable workflows that scale. Includes real recipe demos, common patterns, and a look at community contributions to FleetImporter.
+                </p>
+            </div>
+
+            <div class="speaking-item upcoming co-talk">
+                <div class="speaking-header">
+                    <h3 class="speaking-title">
+                        <a href="https://macadmins.psu.edu/" target="_blank" rel="noopener noreferrer">
+                            Not broken, just different: Working with ADHD, anxiety, and neurodivergence in tech
+                        </a>
+                    </h3>
+                    <div class="speaking-meta">
+                        <span class="speaking-date">July 7–10, 2026</span>
+                        <span class="speaking-venue">Penn State MacAdmins</span>
+                        <span class="speaking-location">State College, PA</span>
+                    </div>
+                    <div class="speaking-cospeaker">
+                        Co-presented with <a href="https://www.linkedin.com/in/lppepper/" target="_blank" rel="noopener noreferrer">Andrea Pepper</a>
+                    </div>
+                </div>
+                <p class="speaking-description">
+                    Mac Admin work requires staying calm while systems break and priorities shift. For neurodivergent people, this creates predictable challenges. Two neurodivergent technical professionals share practical techniques they use to stay effective: time containment, energy-aware scheduling, professional communication strategies, and when to ask for accommodations. You'll leave with concrete tools you can use during incidents, meetings, and when your brain is loud.
                 </p>
             </div>
         </div>

--- a/content/pages/talks.md
+++ b/content/pages/talks.md
@@ -6,7 +6,39 @@ permalink: /talks/
 ---
 
 <div class="markdown-content">
-    <div class="speaking-section archived-talks">
+
+    <div class="speaking-section upcoming-talks">
+        <h2>Upcoming Talks</h2>
+        <div class="speaking-grid">
+            <div class="speaking-item upcoming">
+                <div class="speaking-header">
+                    <div class="upcoming-badge">Upcoming</div>
+                    <h3 class="speaking-title">
+                        <a href="https://pshsummit2026.sched.com/event/2AaQT/stop-clicking-and-start-committing-a-gitops-workflow-for-endpoint-management?iframe=no" target="_blank" rel="noopener noreferrer">
+                            Stop clicking and start committing: a GitOps workflow for endpoint management
+                        </a>
+                    </h3>
+                    <div class="speaking-meta">
+                        <span class="speaking-date">April 15, 2026</span>
+                        <span class="speaking-venue">PowerShell + DevOps Global Summit</span>
+                        <span class="speaking-location">Bellevue, WA</span>
+                    </div>
+                </div>
+                <p class="speaking-description">
+                    Every other discipline in IT figured this out years ago. This talk makes the case for moving your MDM into a Git repository — covering why endpoint management got stuck in ClickOps, what config-as-code buys you that a GUI never can (history, diffs, code review, rollbacks), and how AI coding tools accelerate the workflow without removing human review. Includes a live demo of a working sandbox-to-production pipeline with fleetctl and GitHub Actions.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="archived-talks-toggle-container">
+        <button id="toggle-archived-talks" class="toggle-archived-btn">
+            Show archived talks
+        </button>
+    </div>
+
+    <div id="archived-talks-section" class="speaking-section archived-talks" style="display: none;">
+        <h2>Archived Talks</h2>
         <p class="archive-note">These are talks from earlier in my life that I'm still proud of, though they reflect an earlier version of myself that I no longer identify with.</p>
         
         <div class="speaking-grid">
@@ -211,4 +243,5 @@ permalink: /talks/
             </div>
         </div>
     </div>
+
 </div>

--- a/styles.css
+++ b/styles.css
@@ -1493,6 +1493,67 @@ body {
     font-style: italic;
 }
 
+/* Upcoming talks */
+.upcoming-talks h2 {
+    color: #3fb950;
+}
+
+.speaking-item.upcoming {
+    background: #0d1117;
+    border-color: #238636;
+}
+
+.speaking-item.upcoming:hover {
+    border-color: #3fb950;
+    background: #0d1117;
+}
+
+.upcoming-badge {
+    display: inline-block;
+    background: #1a4428;
+    color: #3fb950;
+    border: 1px solid #238636;
+    border-radius: 12px;
+    padding: 2px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+}
+
+.speaking-location {
+    font-size: 13px;
+    color: #7d8590;
+}
+
+.speaking-location::before {
+    content: "📍 ";
+}
+
+/* Archived talks toggle */
+.archived-talks-toggle-container {
+    margin: 8px 0 24px 0;
+}
+
+.toggle-archived-btn {
+    background: #21262d;
+    color: #7d8590;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.toggle-archived-btn:hover {
+    background: #30363d;
+    color: #e6edf3;
+    border-color: #484f58;
+}
+
 /* Responsive design for speaking */
 @media (max-width: 768px) {
     .speaking-grid {

--- a/styles.css
+++ b/styles.css
@@ -1300,7 +1300,7 @@ body {
 
 .speaking-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    grid-template-columns: 1fr;
     gap: 16px;
     margin-top: 16px;
 }
@@ -1387,12 +1387,33 @@ body {
     background: #0a0c10;
     border-color: #21262d;
     opacity: 0.9;
+    display: grid;
+    grid-template-columns: 1fr 260px;
+    grid-template-rows: auto 1fr;
+    column-gap: 16px;
 }
 
 .speaking-item.archived:hover {
     border-color: #7d8590;
     background: #161b22;
     opacity: 1;
+}
+
+.speaking-item.archived .speaking-thumbnail {
+    grid-column: 2;
+    grid-row: 1 / 3;
+    margin-bottom: 0;
+}
+
+.speaking-item.archived .speaking-header {
+    grid-column: 1;
+    grid-row: 1;
+}
+
+.speaking-item.archived .speaking-description {
+    grid-column: 1;
+    grid-row: 2;
+    align-self: start;
 }
 
 .speaking-item.archived .speaking-title a {
@@ -1495,24 +1516,26 @@ body {
 
 /* Upcoming talks */
 .upcoming-talks h2 {
-    color: #3fb950;
+    color: #f0f6fc;
 }
+
+
 
 .speaking-item.upcoming {
     background: #0d1117;
-    border-color: #238636;
+    border-color: #30363d;
 }
 
 .speaking-item.upcoming:hover {
-    border-color: #3fb950;
-    background: #0d1117;
+    border-color: #58a6ff;
+    background: #161b22;
 }
 
 .upcoming-badge {
     display: inline-block;
-    background: #1a4428;
-    color: #3fb950;
-    border: 1px solid #238636;
+    background: #1c2128;
+    color: #58a6ff;
+    border: 1px solid #388bfd;
     border-radius: 12px;
     padding: 2px 10px;
     font-size: 12px;
@@ -1529,6 +1552,21 @@ body {
 
 .speaking-location::before {
     content: "📍 ";
+}
+
+.speaking-cospeaker {
+    font-size: 13px;
+    color: #7d8590;
+    margin-top: 4px;
+}
+
+.speaking-cospeaker a {
+    color: #58a6ff;
+    text-decoration: none;
+}
+
+.speaking-cospeaker a:hover {
+    text-decoration: underline;
 }
 
 /* Archived talks toggle */
@@ -1562,6 +1600,26 @@ body {
     
     .speaking-item {
         padding: 12px;
+    }
+
+    .speaking-item.archived {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto;
+    }
+
+    .speaking-item.archived .speaking-thumbnail {
+        grid-column: 1;
+        grid-row: 1;
+    }
+
+    .speaking-item.archived .speaking-header {
+        grid-column: 1;
+        grid-row: 2;
+    }
+
+    .speaking-item.archived .speaking-description {
+        grid-column: 1;
+        grid-row: 3;
     }
     
     .speaking-meta {


### PR DESCRIPTION
- Adds **Talks** to site navigation between Projects and Podcasts
- Adds **Upcoming Talks** section with 5 confirmed talks:
  - PowerShell + DevOps Global Summit (April 15, Bellevue WA)
  - MacDevOps:YVR x2 (June 25–26, Montreal QC) — including co-talk with Andrea Pepper
  - Penn State MacAdmins x2 (July 7–10, State College PA) — including co-talk with Andrea Pepper
- All archived talks hidden behind a **Show archived talks** toggle
- Archived talks display with text left, video thumbnail right
- All speaking grids now stack vertically (single column)
- Podcasts page updated to match talks page spacing
- Adds `talks-toggle.js` for the toggle behavior
- New CSS for upcoming cards, co-speaker credit, location meta, and toggle button