### PR TITLE
Style consistency improvements across site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 <head>
     {% include head.html %}
 </head>
-<body>
+<body data-layout="{{ page.layout }}" data-permalink="{{ page.permalink | default: page.url }}">
     <div class="container">
         {% include sidebar.html %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -32,6 +32,25 @@ layout: default
     
     {{ content }}
 
+    <nav class="post-nav">
+        {% if page.previous.url %}
+            <a href="{{ page.previous.url | relative_url }}" class="post-nav-link post-nav-prev">
+                <span class="post-nav-arrow">‹</span>
+                <span class="post-nav-label">{{ page.previous.title }}</span>
+            </a>
+        {% else %}
+            <span class="post-nav-link post-nav-prev post-nav-disabled"></span>
+        {% endif %}
+        {% if page.next.url %}
+            <a href="{{ page.next.url | relative_url }}" class="post-nav-link post-nav-next">
+                <span class="post-nav-label">{{ page.next.title }}</span>
+                <span class="post-nav-arrow">›</span>
+            </a>
+        {% else %}
+            <span class="post-nav-link post-nav-next post-nav-disabled"></span>
+        {% endif %}
+    </nav>
+
     {% unless page.comments == false %}
     <script src="https://giscus.app/client.js"
             data-repo="kitzy/kitzy.com"

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,8 +10,13 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     
-    // Add anchor links to headings
-    addHeadingAnchors();
+    // Add anchor links to headings (only on blog posts and readme page)
+    const body = document.body;
+    const layout = body.getAttribute('data-layout');
+    const permalink = body.getAttribute('data-permalink');
+    if (layout === 'post' || permalink === '/readme/') {
+        addHeadingAnchors();
+    }
     
     // Enhanced code block styling
     enhanceCodeBlocks();

--- a/styles.css
+++ b/styles.css
@@ -532,6 +532,59 @@ body {
     background: #21262d;
 }
 
+.blog-posts {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 16px;
+}
+
+.blog-post-preview {
+    background: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    padding: 16px;
+    transition: all 0.2s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.blog-post-preview:hover {
+    border-color: #58a6ff;
+    background: #161b22;
+}
+
+.blog-post-preview h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.blog-post-preview h3 a {
+    color: #58a6ff;
+    text-decoration: none;
+}
+
+.blog-post-preview h3 a:hover {
+    text-decoration: underline;
+}
+
+.blog-post-preview p {
+    margin: 0;
+    font-size: 14px;
+    color: #e6edf3;
+}
+
+.blog-post-preview .post-meta {
+    margin-bottom: 0;
+}
+
+.blog-post-preview .post-meta time::before {
+    content: "📅 ";
+    margin-right: 4px;
+}
+
 .blog-post-title {
     font-size: 18px;
     font-weight: 600;
@@ -554,6 +607,71 @@ body {
 .blog-post-excerpt {
     color: #e6edf3;
     font-size: 14px;
+}
+
+/* Post prev/next navigation */
+.post-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 48px;
+    margin-bottom: 32px;
+    border-top: 1px solid #30363d;
+    padding-top: 24px;
+}
+
+.post-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    background: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    text-decoration: none;
+    color: #e6edf3;
+    font-size: 14px;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    max-width: 48%;
+    min-width: 0;
+}
+
+.post-nav-link:hover {
+    border-color: #58a6ff;
+    background: #161b22;
+    color: #58a6ff;
+    text-decoration: none;
+}
+
+.post-nav-prev {
+    margin-right: auto;
+}
+
+.post-nav-next {
+    margin-left: auto;
+}
+
+.post-nav-arrow {
+    font-size: 20px;
+    line-height: 1;
+    color: #7d8590;
+    flex-shrink: 0;
+}
+
+.post-nav-link:hover .post-nav-arrow {
+    color: #58a6ff;
+}
+
+.post-nav-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.post-nav-disabled {
+    visibility: hidden;
+    pointer-events: none;
 }
 
 /* Post metadata styles */
@@ -1193,7 +1311,7 @@ body {
 }
 
 .featured-project {
-    border: 1px solid #388bfd;
+    border: 1px solid #30363d;
     border-radius: 6px;
     padding: 20px;
     background-color: #0d1117;
@@ -1201,7 +1319,7 @@ body {
 }
 
 .featured-project:hover {
-    border-color: #79c0ff;
+    border-color: #58a6ff;
     background-color: #161b22;
 }
 


### PR DESCRIPTION
- **Blog post cards**: Main page posts now render as cards matching the talks/podcasts style (gray border, blue on hover, calendar icon on dates)
- **Project card border**: Removed blue outline from featured project cards; now uses the same gray border as the rest of the site
- **Prev/next post nav**: Added previous/next navigation links at the bottom of each blog post, styled as cards with post titles and chevrons
- **Anchor links scoped**: Heading anchor links now only render on blog posts and the `/readme/` page — not on talks, podcasts, projects, etc.