### PR TITLE
Purge Cloudflare cache after Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,3 +66,16 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Purge Cloudflare cache
+        run: |
+          curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}' | tee /tmp/cf_purge_response.json
+          if ! grep -q '"success":true' /tmp/cf_purge_response.json; then
+            echo "Cloudflare cache purge failed:"
+            cat /tmp/cf_purge_response.json
+            exit 1
+          fi
+          echo "Cloudflare cache purged successfully"


### PR DESCRIPTION
Adds a final step to the deploy job that calls the Cloudflare API to purge the entire zone cache after a successful GitHub Pages deployment.

**What it does:**
- Calls `POST /zones/{zone_id}/purge_cache` with `purge_everything: true`
- Validates the response and fails the job if the purge was unsuccessful
- Only runs on merges to `main` (same condition as the deploy job)

**Required secrets (Settings → Secrets and variables → Actions):**
- `CLOUDFLARE_ZONE_ID` — found on your zone's overview page in the Cloudflare dashboard
- `CLOUDFLARE_API_TOKEN` — create at My Profile → API Tokens with Cache Purge permission scoped to this zone