### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
           JEKYLL_ENV: production
           
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v4
 
   deploy:
     environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -40,7 +40,7 @@ jobs:
           
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
         
       - name: Install dependencies
         run: |
@@ -53,7 +53,7 @@ jobs:
           JEKYLL_ENV: production
           
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     environment:
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Purge Cloudflare cache
         run: |


### PR DESCRIPTION
Resolves deprecation warnings for Node.js 20 actions before the June 2, 2026 forced migration deadline.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/configure-pages` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

All updated versions run on Node.js 24.