### PR TITLE
Increase blog post title size to match talks page

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -557,7 +557,7 @@ body {
 
 .blog-post-preview h3 {
     margin: 0;
-    font-size: 16px;
+    font-size: 20px;
     font-weight: 600;
 }
 


### PR DESCRIPTION
Bumps `.blog-post-preview h3` font size from 16px to 20px so homepage blog post titles are the same size as talk titles on the talks page.