### PR TITLE
Remove politics tag from posts

### DIFF
--- a/content/_posts/2026/01/2026-01-25-watch-the-videos.md
+++ b/content/_posts/2026/01/2026-01-25-watch-the-videos.md
@@ -3,7 +3,7 @@ layout: post
 title: "Watch the videos. Then tell me who the terrorists are."
 description: "Federal agents executed two US citizens in Minneapolis in three weeks. Neither was breaking any laws. The administration is now using their deaths to demand access to Minnesota's voter rolls."
 date: 2026-01-25
-tags: [values, community, politics]
+tags: [values, community]
 ---
 
 Two US citizens were executed by federal agents in Minneapolis this month. Neither was breaking any laws. Both were 37 years old. The administration labeled both as violent terrorists. Video evidence contradicts every official claim.

--- a/content/_posts/2026/01/2026-01-28-tech-industry-built-fascism.md
+++ b/content/_posts/2026/01/2026-01-28-tech-industry-built-fascism.md
@@ -3,7 +3,7 @@ layout: post
 title: "The tech industry built the machinery of American fascism"
 description: "Scholars say the U.S. no longer qualifies as a democracy. The tech industry built the tools that made this possible."
 date: 2026-01-28
-tags: [values, AI, community, politics]
+tags: [values, AI, community]
 ---
 
 Fascism in the digital age requires two machines working in tandem: a propaganda apparatus to control what people believe, and a surveillance apparatus to find, track, and remove the people targeted by those narratives.

--- a/content/_posts/2026/03/2026-03-28-does-idahos-bathroom-ban-protect-women.md
+++ b/content/_posts/2026/03/2026-03-28-does-idahos-bathroom-ban-protect-women.md
@@ -3,7 +3,7 @@ layout: post
 title: "Does Idaho's bathroom ban protect women?"
 description: "Idaho's HB 752 creates felony penalties for using the wrong bathroom - harsher than drunk driving. Let's ask honestly whether it accomplishes what it claims."
 date: 2026-03-28
-tags: [politics, community, belonging]
+tags: [community, belonging]
 ---
 
 Let me start with something I don't want to gloss over: the concern behind this kind of legislation is real.

--- a/content/_posts/2026/04/2026-04-27-palantir-manifesto-technofascist-blueprint.md
+++ b/content/_posts/2026/04/2026-04-27-palantir-manifesto-technofascist-blueprint.md
@@ -3,7 +3,7 @@ layout: post
 title: "The Palantir Manifesto is a technofascist blueprint"
 description: "The Technological Republic isn't political philosophy. It's the ideological scaffolding for technofascism, written by the people who profit from it."
 date: 2026-04-27
-tags: [politics, capitalism, AI, values]
+tags: [capitalism, AI, values]
 published: true
 ---
 


### PR DESCRIPTION
## Summary
- Removes the `politics` tag from the 4 posts that had it
- All affected posts retain their other tags; none were left tag-less

## Affected posts
- `2026-01-25-watch-the-videos.md` → `[values, community]`
- `2026-01-28-tech-industry-built-fascism.md` → `[values, AI, community]`
- `2026-03-28-does-idahos-bathroom-ban-protect-women.md` → `[community, belonging]`
- `2026-04-27-palantir-manifesto-technofascist-blueprint.md` → `[capitalism, AI, values]`

## Test plan
- [ ] Verify each post renders correctly without the politics tag
- [ ] Confirm no broken links to a `/tags/politics` page (if one was generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)