### PR TITLE
Bump actions/upload-pages-artifact to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,9 +53,7 @@ jobs:
           JEKYLL_ENV: production
           
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- Bump `actions/upload-pages-artifact` from v4 to v5, which wraps `upload-artifact@v7` and runs on Node.js 24 natively
- Drop the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround that is no longer needed
- Clears the Node.js 20 deprecation warning surfaced on the build job

## Test plan
- [ ] CI build job runs cleanly without the Node 20 deprecation warning
- [ ] Pages artifact uploads successfully and deploy job publishes the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)