### PR TITLE
Add "trans rights" tag to posts centrally about trans rights

### DIFF
--- a/content/_posts/2026/03/2026-03-09-stepping-down-again.md
+++ b/content/_posts/2026/03/2026-03-09-stepping-down-again.md
@@ -3,7 +3,7 @@ layout: post
 title: "Stepping down (again) from the MacAdmins Slack admin team"
 description: "On burnout, harassment, and knowing when to step back"
 date: 2026-03-09
-tags: [community, mental health, burnout, personal]
+tags: [community, mental health, burnout, personal, trans rights]
 comments: false
 published: true
 ---

--- a/content/_posts/2026/03/2026-03-28-does-idahos-bathroom-ban-protect-women.md
+++ b/content/_posts/2026/03/2026-03-28-does-idahos-bathroom-ban-protect-women.md
@@ -3,7 +3,7 @@ layout: post
 title: "Does Idaho's bathroom ban protect women?"
 description: "Idaho's HB 752 creates felony penalties for using the wrong bathroom - harsher than drunk driving. Let's ask honestly whether it accomplishes what it claims."
 date: 2026-03-28
-tags: [community, belonging]
+tags: [community, belonging, trans rights]
 ---
 
 Let me start with something I don't want to gloss over: the concern behind this kind of legislation is real.

--- a/content/_posts/2026/05/2026-05-11-i-dont-know-how-to-keep-showing-up.md
+++ b/content/_posts/2026/05/2026-05-11-i-dont-know-how-to-keep-showing-up.md
@@ -3,7 +3,7 @@ layout: post
 title: "I don't know how to keep showing up like everything is normal"
 description: "The viral image is sensationalized. The infrastructure behind it is not."
 date: 2026-05-11
-tags: [mental health, life, AI]
+tags: [mental health, life, AI, trans rights]
 ---
 
 An image has been circulating on social media this week. Maybe you've seen it.


### PR DESCRIPTION
## Summary
- Adds the existing `trans rights` tag to three posts where trans rights is the central topic but the tag was missing
  - `2026-03-09-stepping-down-again.md` — transphobic harassment driving the decision to step down
  - `2026-03-28-does-idahos-bathroom-ban-protect-women.md` — Idaho HB 752 anti-trans bathroom legislation
  - `2026-05-11-i-dont-know-how-to-keep-showing-up.md` — "radically pro-transgender" CT designation, Kansas ID invalidations

Posts with passing mentions only (Palantir manifesto, "What the hell are you still doing on X?") were left untagged.

## Test plan
- [x] Confirm the three posts render on the `trans rights` tag page alongside `2026-05-26-erasure-is-the-first-step.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)