### PR TITLE
Migrate redirects into the _redirects collection

### DIFF
--- a/content/_redirects/blog-we-will-find-you.md
+++ b/content/_redirects/blog-we-will-find-you.md
@@ -1,5 +1,4 @@
 ---
-layout: redirect
 permalink: /blog/we-will-find-you/
 redirect_url: /blog/i-dont-know-how-to-keep-showing-up/
 ---

--- a/content/_redirects/blog.md
+++ b/content/_redirects/blog.md
@@ -1,5 +1,4 @@
 ---
-layout: redirect
 permalink: /blog/
 redirect_url: /
 ---

--- a/content/_redirects/broadcast.md
+++ b/content/_redirects/broadcast.md
@@ -1,5 +1,4 @@
 ---
-layout: redirect
 redirect_url: https://kitzysound.com
-permalink: /live/
+permalink: /broadcast/
 ---

--- a/content/_redirects/live.md
+++ b/content/_redirects/live.md
@@ -1,5 +1,4 @@
 ---
-layout: redirect
 redirect_url: https://kitzysound.com
-permalink: /broadcast/
+permalink: /live/
 ---

--- a/content/_redirects/studio.md
+++ b/content/_redirects/studio.md
@@ -1,5 +1,4 @@
 ---
-layout: redirect
 redirect_url: https://kitzysound.com
 permalink: /studio/
 ---


### PR DESCRIPTION
## Summary

The site declares a `redirects` collection in `_config.yml` (`output: true`, with a default `layout: redirect`), but it was effectively dead config: the actual redirect files lived in `content/redirects/` — **no underscore** — so Jekyll treated them as plain pages, not collection items. As a result each file had to repeat an explicit `layout: redirect`.

This standardizes on the intended design:

- Move all redirect files from `content/redirects/` → `content/_redirects/` (the collection's directory, given `collections_dir: content`)
- Drop the now-redundant `layout: redirect` line from each (the collection default in `_config.yml` supplies it)

No config changes and **no URLs change** — this is purely consolidating onto the mechanism that was already configured.

(Follows #241, which added the trillionaire redirect already in `content/_redirects/`.)

## Testing

`bundle exec jekyll build` produces identical redirect output for every entry:

| Path | Redirects to |
|------|--------------|
| `/blog/we-will-find-you/` | `/blog/i-dont-know-how-to-keep-showing-up/` |
| `/blog/` | `/` |
| `/broadcast/` | `https://kitzysound.com` |
| `/live/` | `https://kitzysound.com` |
| `/studio/` | `https://kitzysound.com` |
| `/blog/no-ehtical-way-to-become-a-trillionaire/` | `/blog/no-ethical-way-to-become-a-trillionaire/` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)