### PR TITLE
Add content/_drafts/ to gitignore for unpublished posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ _site/
 .jekyll-cache/
 .jekyll-metadata
 
+# Unpublished drafts
+content/_drafts/
+
 # Ruby dependencies
 vendor/
 .bundle/


### PR DESCRIPTION
Adds `content/_drafts/` to `.gitignore` so unpublished/in-progress posts can live in the repo working tree without being committed or built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)