### PR TITLE
Increase paragraph spacing in blog posts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -453,7 +453,7 @@ body {
 }
 
 .markdown-content p {
-    margin-bottom: 16px;
+    margin-bottom: 24px;
     color: #e6edf3;
 }
 


### PR DESCRIPTION
## Summary

- Increases `.markdown-content p` `margin-bottom` from `16px` to `24px` to add more breathing room between paragraphs in blog posts.

## Test plan

- [ ] Visit a blog post and confirm paragraph spacing looks less cluttered

🤖 Generated with [Claude Code](https://claude.com/claude-code)