### PR TITLE
Add spacing around hr dividers in blog posts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -457,6 +457,12 @@ body {
     color: #e6edf3;
 }
 
+.markdown-content hr {
+    margin: 32px 0;
+    border: none;
+    border-top: 1px solid #30363d;
+}
+
 .markdown-content a {
     color: #58a6ff;
     text-decoration: none;


### PR DESCRIPTION
## Summary

- Adds `margin: 32px 0` to `<hr>` elements in `.markdown-content` so text isn't flush against the horizontal dividers in blog posts.

## Test plan

- [ ] Visit a blog post with `---` dividers and confirm text has breathing room above and below the lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)