### PR TITLE
Add Plausible analytics opt-out page

### DIFF
--- a/content/pages/plausible-exclude.md
+++ b/content/pages/plausible-exclude.md
@@ -1,0 +1,51 @@
+---
+layout: default
+title: "Analytics Opt-Out"
+description: "Opt out of Plausible Analytics tracking on this site."
+permalink: /plausible-exclude/
+---
+
+<div class="exclude-panel">
+    <h1>Analytics Opt-Out</h1>
+    <p>This site uses <a href="https://plausible.io" target="_blank" rel="noopener noreferrer">Plausible Analytics</a>, a privacy-friendly analytics tool. If you'd rather not be counted in the visit stats, use the toggle below to exclude your browser from tracking.</p>
+
+    <div class="exclude-status">
+        You are currently <strong id="exclude-state">not excluding</strong> your visits from analytics.
+    </div>
+
+    <button type="button" id="exclude-toggle" class="exclude-button">Exclude my visits</button>
+
+    <p class="exclude-note">This works by setting a flag in your browser's local storage, so it only applies to this browser on this device.</p>
+</div>
+
+<script>
+(function () {
+    var stateEl = document.getElementById('exclude-state');
+    var buttonEl = document.getElementById('exclude-toggle');
+
+    function isExcluded() {
+        return window.localStorage.plausible_ignore === 'true';
+    }
+
+    function render() {
+        if (isExcluded()) {
+            stateEl.textContent = 'excluding';
+            buttonEl.textContent = 'Stop excluding my visits';
+        } else {
+            stateEl.textContent = 'not excluding';
+            buttonEl.textContent = 'Exclude my visits';
+        }
+    }
+
+    buttonEl.addEventListener('click', function () {
+        if (isExcluded()) {
+            window.localStorage.removeItem('plausible_ignore');
+        } else {
+            window.localStorage.plausible_ignore = 'true';
+        }
+        render();
+    });
+
+    render();
+})();
+</script>

--- a/styles.css
+++ b/styles.css
@@ -1581,3 +1581,40 @@ body {
         gap: 4px;
     }
 }
+
+/* Analytics opt-out page styles */
+.exclude-panel {
+    max-width: 520px;
+}
+
+.exclude-status {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    padding: 16px;
+    margin: 20px 0;
+    color: #e6edf3;
+}
+
+.exclude-button {
+    background: #21262d;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #e6edf3;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    padding: 10px 20px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.exclude-button:hover {
+    background: #30363d;
+    border-color: #58a6ff;
+}
+
+.exclude-note {
+    font-size: 13px;
+    color: #7d8590;
+}


### PR DESCRIPTION
## Summary
- Adds a standalone page at `/plausible-exclude/` where visitors can toggle a local-storage flag to exclude their visits from Plausible Analytics tracking.
- Uses the site's `default` layout so it inherits the header/sidebar/footer and matches the rest of the site visually, but is intentionally left out of `site.navigation` in `_config.yml`, so it's only reachable via direct URL.
- Adds a small `.exclude-panel`/`.exclude-status`/`.exclude-button` styling block to `styles.css` using the existing GitHub-dark palette.

## Test plan
- [ ] `bundle exec jekyll serve` and visit `/plausible-exclude/` to confirm it renders with site styling
- [ ] Click "Exclude my visits", confirm text/button state updates and `localStorage.plausible_ignore` is set to `"true"`
- [ ] Click "Stop excluding my visits", confirm it reverts and the localStorage key is removed
- [ ] Confirm the page does not appear in the top navigation