### PR TITLE
Publish "I was afraid to go back to Penn State Mac Admins. I'm glad I did."

### DIFF
--- a/content/_posts/2026/07/2026-07-13-afraid-to-go-back-to-penn-state-mac-admins.md
+++ b/content/_posts/2026/07/2026-07-13-afraid-to-go-back-to-penn-state-mac-admins.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: "I was afraid to go back to Penn State Mac Admins. I'm glad I did."
+description: "Seven years since my last Penn State Mac Admins, and after everything that happened this spring, I wasn't sure how I'd be received. I was wrong to worry."
+date: 2026-07-13
+tags: [community, mac admin, belonging, trans rights, personal]
+---
+
+I hadn't been to Penn State Mac Admins since 2019.
+
+Seven years is a long time in this industry. Long enough for MDMs to get acquired and rebrand twice. Long enough for entire toolchains to become legacy. It's also long enough for me to become a version of myself almost nobody at that conference had met before.
+
+Most of the community I've built since 2019 has only ever known me as me. Penn State was different. Penn State was full of people from before - people I sat next to in sessions a decade ago, people I chatted with about MDM profiles in hallway tracks, people whose only frame of reference for me was a version of me that doesn't exist anymore.
+
+I said yes to the CFP months ago, back when it felt like an easy decision made by a version of me with more bandwidth. By the time July actually showed up, so did the fear.
+
+## What I was actually afraid of
+
+[Earlier this year](https://kitzy.com/blog/stepping-down-again/), I rejoined the MacAdmins Slack admin team and got doxxed for it. Someone posted my home address and phone number in a forum built for harassing trans people. I got a "wellness check" from police I never called. I'm still getting mail addressed to my deadname. That wasn't some anonymous stranger with no connection to this world - that was someone who cared enough about my involvement in the Mac admin community to weaponize it against me.
+
+A Slack thread is something you can walk away from. You close the laptop, you get some distance, the feeling passes. A conference is physical. You can't mute a hallway. You can't skip a day without someone noticing. If people who knew me before had a problem with who I am now, I was going to find out in person, in real time, with nowhere to go.
+
+Maybe I would've backed out entirely if I hadn't already committed to a talk. Maybe I needed the external pressure to make myself show up. Maybe some part of me just needed to know, one way or another, instead of carrying the question around for another year.
+
+## What actually happened
+
+Not one thing I feared.
+
+People I hadn't seen since 2019 hugged me and picked conversations back up like no time had passed. Nobody stumbled over my name. Nobody got that careful, over-managed tone people use when they're trying very hard not to make something weird. And nobody gave me the look - the little-too-long once-over some people do when they're trying to work out if I'm *really* the gender I'm presenting as. I know that look. I didn't get it once. I gave my talks on AutoPkg and neurodivergence, worked the Fleet booth, and every conversation was about the work. Nobody treated me like a topic. Everybody just treated me like a member of the community.
+
+I know how low a bar that sounds like. Being treated like a person shouldn't be a story. But I'd spent months bracing for the alternative, and getting the ordinary version instead - after the year I've had - felt like something.
+
+## The thing I actually didn't expect
+
+I expected, at best, to not be a problem. What I didn't expect was how many visibly queer people were there. Pronoun pins, rainbow lanyards, people I recognized from the internet suddenly standing in front of me in person. I wasn't the only trans person at Penn State Mac Admins this year, and that was honestly a surprise.
+
+I don't fully know what to do with that yet. Maybe it's always been true and I just wasn't looking, back before I had a reason to count. Maybe the community has actually gotten more visibly queer since 2019, the way a lot of tech spaces slowly have. Maybe people who'd have stayed quiet about it a few years ago just don't feel like they have to anymore, at least not at this particular conference. I don't know which of those is true, or if it's some mix of all three. What I know is that I walked into the conference expecting to be an exception and walked out having lost count.
+
+## Two things can both be true
+
+The internet that doxxed me and the room full of people who hugged me are supposedly the same community. I've been sitting with that all week. My best guess - and it is a guess - is that the internet optimizes for exactly the wrong sample. Anonymity gives the worst-faith person in a community of thousands the same reach as everyone else combined, for free, with none of the social cost that would normally keep them in check. A conference selects for something closer to the opposite: people who cared enough to request time off, book travel, and show up in a room where they're accountable for how they treat the person standing in front of them. That's not proof the community is safe. It's evidence that the people willing to hurt me and the people who make up this community are, mostly, not the same people - even when they're using the same Slack.
+
+I'm not writing this to pretend the spring didn't happen. It happened, it was real, and I'm not going to round it down for a tidier ending. But it's also true that a room full of Mac admins - some of whom knew a different version of me, some of whom are trans themselves, all of whom just wanted to talk about deployment pipelines - gave me something the internet couldn't take back.
+
+I stayed away from Penn State Mac Admins for seven years for a lot of reasons that had nothing to do with any of this. But I almost let fear be the reason I stayed away for an eighth. I'm glad I didn't. I'm proud to be part of this community - not the sanitized version of it, the actual one, doxxing and all - and I'm already thinking about what I'm submitting next year.


### PR DESCRIPTION
Publishes the draft on **2026-07-13**. The post is future-dated, so it stays unbuilt until the daily 4am ET scheduled build on the 13th picks it up.

- Moves `content/_drafts/afraid-to-go-back-to-penn-state-mac-admins.md` → `content/_posts/2026/07/2026-07-13-afraid-to-go-back-to-penn-state-mac-admins.md`
- Adds `date: 2026-07-13` to the frontmatter
- Fixes typo: "involvment" → "involvement"

🤖 Generated with [Claude Code](https://claude.com/claude-code)