### PR TITLE
Move scheduled-post build from 04:00 to 13:00 UTC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,11 @@ on:
     branches: [ main ]
   # Allow manual triggering
   workflow_dispatch:
-  # Run daily at 4am US Eastern Time (9am UTC) to publish scheduled posts
+  # Run daily at 9am US Eastern Time (1pm UTC) to publish scheduled posts.
+  # Cron is UTC-only, so this is 9am EDT in summer and 8am EST in winter.
   # Run weekly on Sunday to update language data
   schedule:
-    - cron: '0 9 * * *'  # Daily at 4am EST/EDT
+    - cron: '0 13 * * *'  # Daily at 9am EDT / 8am EST
     - cron: '0 0 * * 0'  # Weekly on Sunday
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
Changes the daily publish cron from `0 9 * * *` (4am ET) to `0 13 * * *` (9am ET).

**DST caveat:** GitHub Actions cron only accepts UTC, so 13:00 UTC is 9am ET during EDT (Mar–Nov) and 8am ET during EST (Nov–Mar). Getting exactly 9am year-round would need a gate job that checks the Eastern hour and skips the build — happy to add that if the winter drift matters.

The weekly Sunday language-data cron is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)