### PR TITLE
Strengthen author metadata on posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,13 @@ description: "Always automating, always iterating, always helping others."
 baseurl: ""
 url: "https://kitzy.com"
 author: "Kitzy"
+author_url: "https://kitzy.com/readme/"
+author_image: "https://github.com/kitzy.png"
+author_profiles:
+  - "https://github.com/kitzy"
+  - "https://linkedin.com/in/kitzy"
+  - "https://bsky.app/profile/kitzy.com"
+  - "https://hachyderm.io/@kitzy"
 timezone: America/New_York
 
 # GitHub settings

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,10 +24,14 @@
   {% assign social_image_url = social_image | prepend: site.url %}
 {% endif %}
 
+{% comment %} Resolve author: page front matter > site default {% endcomment %}
+{% assign page_author = page.author | default: site.author %}
+{% assign page_description = page.description | default: site.description %}
+
 <!-- SEO and Social Media Meta Tags -->
 <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 <meta name="keywords" content="infrastructure, automation, IT engineering, endpoint management, Fleet, DevOps{% if page.tags %}, {{ page.tags | join: ', ' }}{% endif %}">
-<meta name="author" content="{{ site.author }}">
+<meta name="author" content="{{ page_author }}">
 
 <!-- Open Graph Meta Tags for Social Previews -->
 <meta property="og:title" content="{% if page.title %}{{ site.title }} - {{ page.title }}{% else %}{{ site.title }}{% endif %}">
@@ -47,15 +51,55 @@
 <meta name="fediverse:creator" content="@kitzy@hachyderm.io">
 
 <!-- LinkedIn/Professional Networks -->
-<meta property="article:author" content="{{ site.title }}">
 {% if page.layout == 'post' %}
+<meta property="article:author" content="{{ site.author_url }}">
 <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
+{% if page.last_modified_at %}
+<meta property="article:modified_time" content="{{ page.last_modified_at | date_to_xmlschema }}">
+{% endif %}
 {% if page.tags %}
 {% for tag in page.tags %}
 <meta property="article:tag" content="{{ tag }}">
 {% endfor %}
 {% endif %}
+{% else %}
+<meta property="profile:username" content="{{ site.github_username }}">
 {% endif %}
+
+<!-- Structured data -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": {% if page.layout == 'post' %}"BlogPosting"{% else %}"WebPage"{% endif %},
+  "headline": {{ page.title | default: site.title | jsonify }},
+  "description": {{ page_description | jsonify }},
+  "image": {{ social_image_url | jsonify }},
+  "url": {{ page.url | prepend: site.url | jsonify }},
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": {{ page.url | prepend: site.url | jsonify }}
+  },
+  {% if page.layout == 'post' %}
+  "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
+  "dateModified": {{ page.last_modified_at | default: page.date | date_to_xmlschema | jsonify }},
+  {% if page.tags %}
+  "keywords": {{ page.tags | join: ', ' | jsonify }},
+  {% endif %}
+  {% endif %}
+  "author": {
+    "@type": "Person",
+    "name": {{ page_author | jsonify }},
+    "url": {{ site.author_url | jsonify }},
+    "image": {{ site.author_image | jsonify }},
+    "sameAs": {{ site.author_profiles | jsonify }}
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": {{ site.author | jsonify }},
+    "url": {{ site.url | jsonify }}
+  }
+}
+</script>
 
 <!-- Canonical URL -->
 <link rel="canonical" href="{{ site.url }}{{ page.url }}">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,6 +9,8 @@ layout: default
     
     {% if page.date %}
         <p class="post-meta">
+            <span class="post-author">By <a href="{{ '/readme/' | relative_url }}" rel="author">{{ page.author | default: site.author }}</a></span>
+            <span class="post-meta-separator">•</span>
             <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time>
             {% assign words = content | number_of_words %}
             {% assign read_time = words | divided_by: 200 | at_least: 1 %}

--- a/styles.css
+++ b/styles.css
@@ -696,6 +696,16 @@ body {
     color: #484f58;
 }
 
+.post-author a {
+    color: #7d8590;
+    text-decoration: none;
+}
+
+.post-author a:hover {
+    color: #58a6ff;
+    text-decoration: underline;
+}
+
 .post-word-count,
 .post-read-time {
     color: #7d8590;


### PR DESCRIPTION
## Why

LinkedIn's Post Inspector reports **"No author found"** on posts. The `<meta name="author" content="Kitzy">` tag was already present on every post via `_includes/head.html`, so this isn't a missing tag — it's most likely a stale scrape, or LinkedIn wanting a stronger signal than a bare `name="author"`. This adds richer, spec-correct author signals instead of just re-adding what was already there.

## What changed

- **`_config.yml`** — added `author_url`, `author_image`, and `author_profiles` (GitHub, LinkedIn, Bluesky, Mastodon). Posts already default to `author: "Kitzy"`, so no post front matter needed touching.
- **`_includes/head.html`**
  - `meta name="author"` now resolves `page.author | default: site.author`, so an individual post can override it.
  - Added a **JSON-LD `BlogPosting`** block with a full `author` Person object (name, url, image, `sameAs`) — the signal Google and most modern scrapers actually read.
  - Scoped `article:author` to posts and pointed it at a profile URL per the Open Graph spec, instead of the bare string `"Kitzy"`.
  - Added `article:modified_time` support (emitted when a post sets `last_modified_at`).
- **`_layouts/post.html`** — visible "By Kitzy" byline linking to `/readme/` with `rel="author"`, in the existing meta row alongside date and read time.
- **`styles.css`** — muted styling for the byline link so it matches the rest of the meta row.

## Verification

Built the site and machine-checked all 54 `_site/blog/*/index.html` files: all **51 real posts** have the author meta tag and parseable JSON-LD with `"@type": "BlogPosting"` and `author.name`. The 3 that don't are redirect stubs, which correctly carry no metadata.

## Notes

- Non-post pages now get a `WebPage` JSON-LD block too, using the same author object.
- The JSON-LD `image` reuses the existing og:image resolution, so posts without an image fall back to the site default.
- After this deploys, re-run LinkedIn's Post Inspector on a post URL to force it to drop the cached scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
