### PR TITLE
Add X World 2026 talks to talks page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.20.0)
+    json (2.21.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)

--- a/content/pages/talks.md
+++ b/content/pages/talks.md
@@ -7,6 +7,47 @@ permalink: /talks/
 
 <div class="markdown-content">
 
+    <div class="speaking-section upcoming-talks">
+        <h2>Upcoming Talks</h2>
+        <div class="speaking-grid">
+            <div class="speaking-item upcoming">
+                <div class="speaking-header">
+                    <h3 class="speaking-title">
+                        <a href="https://xworld.au/presentation/index/260" target="_blank" rel="noopener noreferrer">
+                            Faster, smarter, still in control: AI-accelerated device management
+                        </a>
+                    </h3>
+                    <div class="speaking-meta">
+                        <span class="speaking-date">August 25–26, 2026</span>
+                        <span class="speaking-venue">X World</span>
+                        <span class="speaking-location">Melbourne, Australia</span>
+                    </div>
+                </div>
+                <p class="speaking-description">
+                    Device management teams are asked to do more with less. More platforms, more compliance requirements, more endpoints, and often the same headcount. AI doesn't solve that by replacing the engineer. It solves it by making each engineer faster, more accurate, and less dependent on tribal knowledge they haven't had time to build yet. In this talk, we'll explore what AI-accelerated device management looks like in practice. We'll cover how to give an AI assistant the context it needs to produce accurate, platform-appropriate output, how to validate what it generates, and how to build review practices that keep humans in the loop on what actually ships. We'll demo AI-assisted policy authoring across macOS, Windows, and Linux, showing how to go from a compliance requirement to a tested, production-ready configuration in a fraction of the time it would take manually. You'll leave with a methodology you can apply to your tooling of choice, practical patterns for writing context that makes AI output trustworthy, and a clearer picture of what device management looks like when AI is doing the work it's actually good at.
+                </p>
+            </div>
+
+            <div class="speaking-item upcoming">
+                <div class="speaking-header">
+                    <h3 class="speaking-title">
+                        <a href="https://xworld.au/presentation/index/255" target="_blank" rel="noopener noreferrer">
+                            Stop clicking and start committing: A pull-request workflow for device management
+                        </a>
+                    </h3>
+                    <div class="speaking-meta">
+                        <span class="speaking-date">August 25–26, 2026</span>
+                        <span class="speaking-venue">X World</span>
+                        <span class="speaking-location">Melbourne, Australia</span>
+                    </div>
+                </div>
+                <p class="speaking-description">
+                    Device management is still mostly ClickOps. Config in a GUI, changes made by hand, no audit trail, no rollback, no way to answer "who changed this and why." The case for GitOps, version control, pull request review, and a single source of truth, has been clear for years. What's changed is the urgency. AI is going to fundamentally change how devices are managed. Not eventually, it's already happening. The ergonomic barrier that made config-as-code feel like homework, knowing the schema, writing the YAML, getting the scoping right, is gone. AI coding agents can already turn a sentence of intent into a pull request against your MDM configuration. Teams that have GitOps discipline are positioned to move as each new capability lands. Teams with config in a GUI are going to be doing a migration while everyone else is already running. This session covers why GitOps is the prerequisite for AI-accelerated device management, what that workflow looks like in practice, and what the job looks like when the authoring is handled and the review is what's left. Attendees will leave with a concrete path from ClickOps to a workflow that's ready for what's already here.
+                </p>
+            </div>
+        </div>
+    </div>
+
     <div class="speaking-section past-talks">
         <h2>Past Talks</h2>
         <div class="speaking-grid">


### PR DESCRIPTION
Adds an Upcoming Talks section with both accepted sessions for X World
2026 (Melbourne, Aug 25-26): AI-accelerated device management, and a
GitOps workflow for device management.