### PR TITLE
Add content policy page and make sidebar a mobile footer

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -45,7 +45,11 @@
                 </div>
             </div>
         </div>
-        
 
+
+    </div>
+
+    <div class="sidebar-footer">
+        <a href="{{ '/content-policy/' | relative_url }}">Content policy</a>
     </div>
 </aside>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,12 +33,6 @@
         </main>
     </div>
 
-    <button class="mobile-menu-toggle" id="mobile-menu-toggle">
-        <span></span>
-        <span></span>
-        <span></span>
-    </button>
-
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/blog-pagination.js' | relative_url }}"></script>
 </body>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,15 +1,5 @@
 // Jekyll site - minimal JavaScript for enhanced functionality
 document.addEventListener('DOMContentLoaded', function() {
-    // Mobile menu toggle
-    const mobileMenuToggle = document.getElementById('mobile-menu-toggle');
-    const sidebar = document.querySelector('.sidebar');
-    
-    if (mobileMenuToggle) {
-        mobileMenuToggle.addEventListener('click', function() {
-            sidebar.classList.toggle('active');
-        });
-    }
-    
     // Add anchor links to headings (only on blog posts and readme page)
     const body = document.body;
     const layout = body.getAttribute('data-layout');

--- a/content/pages/content-policy.md
+++ b/content/pages/content-policy.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Content Policy
+description: "Whose opinions this blog reflects, and how AI tools are used in researching, writing, and editing it."
+permalink: /content-policy/
+---
+
+<div class="markdown-content" markdown="1">
+
+## Whose opinions these are
+
+Everything published on this blog reflects my own opinions. It does not represent the views, positions, or opinions of any employer or other organization I am affiliated with, past or present. No employer or other organization has any editorial input into, or approval over, what I publish here.
+
+## AI use
+
+This section describes how I use AI tools when researching, writing, and editing posts on this blog.
+
+### Research
+
+AI tools may be used to help locate sources on a given topic. I read and independently verify every source before citing it in a post.
+
+### Editing
+
+AI tools may be used to assist with sentence structure, flow, and clarity, including rephrasing to more accurately reflect intended meaning.
+
+### What AI does not do
+
+The following always originate with me, without AI assistance:
+
+- The decision to write a given post
+- The conclusions drawn from any research
+- The thesis of every post
+- The arguments that support that thesis
+
+### Accountability
+
+I am responsible for the accuracy of everything published here. Errors are mine, not the AI tool's.
+
+</div>

--- a/styles.css
+++ b/styles.css
@@ -210,6 +210,24 @@ body {
     border-color: #58a6ff;
 }
 
+/* Sidebar footer */
+.sidebar-footer {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #30363d;
+    font-size: 12px;
+}
+
+.sidebar-footer a {
+    color: #7d8590;
+    text-decoration: none;
+}
+
+.sidebar-footer a:hover {
+    color: #58a6ff;
+    text-decoration: underline;
+}
+
 /* GitHub section in About tab */
 .github-section {
     margin-top: 32px;
@@ -914,47 +932,6 @@ body {
     font-size: 14px;
 }
 
-/* Mobile menu toggle */
-.mobile-menu-toggle {
-    display: none;
-    position: fixed;
-    top: 16px;
-    left: 16px;
-    z-index: 1001;
-    background: #21262d;
-    border: 1px solid #30363d;
-    border-radius: 6px;
-    padding: 8px;
-    cursor: pointer;
-    flex-direction: column;
-    gap: 3px;
-    transition: background-color 0.2s ease;
-}
-
-.mobile-menu-toggle:hover {
-    background: #30363d;
-}
-
-.mobile-menu-toggle span {
-    width: 20px;
-    height: 2px;
-    background: #e6edf3;
-    transition: all 0.3s ease;
-    border-radius: 1px;
-}
-
-.mobile-menu-toggle.active span:nth-child(1) {
-    transform: rotate(45deg) translate(5px, 5px);
-}
-
-.mobile-menu-toggle.active span:nth-child(2) {
-    opacity: 0;
-}
-
-.mobile-menu-toggle.active span:nth-child(3) {
-    transform: rotate(-45deg) translate(7px, -6px);
-}
-
 /* Mobile styles */
 @media (max-width: 768px) {
     .container {
@@ -965,31 +942,12 @@ body {
 
     .sidebar {
         flex: none;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 280px;
-        height: 100vh;
-        z-index: 1000;
-        transform: translateX(-100%);
-        transition: transform 0.3s ease;
-        overflow-y: auto;
-        border-radius: 0;
-        border-left: none;
-        border-top: none;
-        border-bottom: none;
-    }
-
-    .sidebar.mobile-open {
-        transform: translateX(0);
-    }
-
-    .mobile-menu-toggle {
-        display: flex;
+        position: static;
+        order: 2;
     }
 
     .main-content {
-        margin-top: 48px;
+        order: 1;
     }
 
     .avatar {


### PR DESCRIPTION
## Summary
- Adds a `/content-policy/` page covering whose opinions the blog reflects and how AI tools are used in researching, writing, and editing posts. Linked from the bottom of the sidebar, intentionally left out of the main nav.
- Reworks the mobile sidebar from a hidden hamburger drawer into an in-flow footer: on narrow viewports, the sidebar (avatar, socials, and the new content policy link) now renders below the page content via flex `order` instead of being hidden behind a toggle that has to be tapped open.
- Removes the now-dead hamburger toggle button, its CSS, and its click handler in `main.js` (the handler toggled a class the CSS never actually matched, so it wasn't functional before this change either).

## Test plan
- [x] `bundle exec jekyll build` succeeds
- [x] Verified `/content-policy/` renders correctly with full content
- [x] Verified in-browser at 375px (mobile): no hamburger icon, sidebar (incl. content policy link) renders as a footer below page content on the podcasts page
- [x] Verified at 1280px (desktop): sidebar renders as before, unaffected, with content policy link at its bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)