### PR TITLE
Use sentence case for Zuckerberg AI post title

### DIFF
--- a/content/_posts/2026/08/2026-08-13-if-zuckerbergs-right-about-ai-and-power-why-doesnt-it-feel-right.md
+++ b/content/_posts/2026/08/2026-08-13-if-zuckerbergs-right-about-ai-and-power-why-doesnt-it-feel-right.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "If Zuckerberg's Right About AI and Power, Why Doesn't It Feel Right?"
+title: "If Zuckerberg's right about AI and power, why doesn't it feel right?"
 description: "Meta's new AI manifesto makes an argument I've made myself, about concentrated power being the real danger. That's exactly why it's worth taking apart."
 date: 2026-08-13
 tags: [AI, capitalism, values, work]


### PR DESCRIPTION
## Summary
- The Zuckerberg AI manifesto post's title was in title case while its section headings were already sentence case; updates the title to match: "If Zuckerberg's right about AI and power, why doesn't it feel right?"
- "AI" and "Zuckerberg" stay capitalized (acronym / proper noun).

## Test plan
- [x] Verified all `##` headings in the post already use sentence case, so no other changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)